### PR TITLE
set operator e2e timeout default to 900s

### DIFF
--- a/configs/test-harness.yaml
+++ b/configs/test-harness.yaml
@@ -1,2 +1,3 @@
 tests:
   ginkgoLabelFilter: TestHarness
+  harnessTimeout: 900


### PR DESCRIPTION
Currently this is unset in jobs, defaults to 300s. Some operators requiring longer times perma fail (eg MNMO) 

Updating the default here would be the fastest way to up the timeout. 