### PR TITLE
feat: add Delivery Dashboard — HTTP server and UI templates

### DIFF
--- a/pkg/dashboard/collectors/deliverables.go
+++ b/pkg/dashboard/collectors/deliverables.go
@@ -1,0 +1,523 @@
+package collectors
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awssession "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/openshift/osde2e/pkg/dashboard/models"
+)
+
+const downloadWorkers = 20
+
+// versionRegex matches semver tags (v1.2.3) or short git SHAs (7-10 hex chars)
+var versionRegex = regexp.MustCompile(`^(v\d+(\.\d+)*|[0-9a-f]{7,10})$`)
+
+var knownEnvSuffixes = []string{"integration", "stage", "prod", "int"}
+
+// DeliverableCollector scans S3 for operator test results grouped by name, version, and environment.
+type DeliverableCollector struct {
+	s3Client     *s3.S3
+	bucket       string
+	region       string
+	lookbackDays int
+}
+
+// NewDeliverableCollector creates a new collector using the standard AWS credential chain
+// (env vars → ~/.aws/credentials → IAM role), independent of the osde2e viper config.
+func NewDeliverableCollector(bucket, region string, lookbackDays int) (*DeliverableCollector, error) {
+	sess, err := awssession.NewSession(aws.NewConfig().WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AWS session: %w", err)
+	}
+
+	s3Client := s3.New(sess)
+
+	if lookbackDays <= 0 {
+		lookbackDays = 30
+	}
+
+	return &DeliverableCollector{
+		s3Client:     s3Client,
+		bucket:       bucket,
+		region:       region,
+		lookbackDays: lookbackDays,
+	}, nil
+}
+
+// S3Client returns the underlying S3 client and bucket name, used by the server's S3 proxy handler.
+func (c *DeliverableCollector) S3Client() (*s3.S3, string) { return c.s3Client, c.bucket }
+
+// parseComponentPath splits an S3 component string into operator name, version, and environment.
+func parseComponentPath(component string) (name, version, env string) {
+	tokens := strings.Split(component, "-")
+
+	env = "unknown"
+	if len(tokens) > 0 {
+		last := tokens[len(tokens)-1]
+		for _, suffix := range knownEnvSuffixes {
+			if strings.EqualFold(last, suffix) {
+				env = strings.ToLower(last)
+				tokens = tokens[:len(tokens)-1]
+				break
+			}
+		}
+	}
+
+	version = "unknown"
+	versionIdx := -1
+	for i := len(tokens) - 1; i >= 0; i-- {
+		if versionRegex.MatchString(tokens[i]) {
+			version = tokens[i]
+			versionIdx = i
+			break
+		}
+	}
+
+	if versionIdx > 0 {
+		name = strings.Join(tokens[:versionIdx], "-")
+	} else if versionIdx == 0 {
+		name = "unknown"
+	} else {
+		name = strings.Join(tokens, "-")
+	}
+
+	if name == "" {
+		name = "unknown"
+	}
+
+	return name, version, env
+}
+
+// candidate holds a JUnit key identified during listing, before downloading.
+type candidate struct {
+	key       string
+	component string
+	dateStr   string
+	jobID     string
+	modified  time.Time // S3 LastModified, used to pick the newest per group
+}
+
+// downloadResult is the outcome of fetching and parsing one candidate.
+type downloadResult struct {
+	name    string
+	version string
+	env     string
+	jobID   string
+	s3Dir   string
+	key     string
+	suite   *JUnitTestSuite
+	ts      time.Time
+}
+
+// CollectDeliverables scans S3 for junit XML files within the lookback window,
+// groups them by operator name + version, and returns the latest result per environment.
+func (c *DeliverableCollector) CollectDeliverables() ([]models.DeliverableStatus, error) {
+	cutoff := time.Now().UTC().AddDate(0, 0, -c.lookbackDays)
+
+	// Phase 1: list all matching keys, deduplicate to newest per (name, version, env).
+	// S3 listing is cheap; downloading is not. We only download one file per group.
+	type groupKey struct{ name, version, env string }
+	newestByGroup := make(map[groupKey]*candidate)
+
+	input := &s3.ListObjectsV2Input{
+		Bucket: aws.String(c.bucket),
+		Prefix: aws.String("test-results/"),
+	}
+
+	err := c.s3Client.ListObjectsV2Pages(input, func(page *s3.ListObjectsV2Output, _ bool) bool {
+		for _, obj := range page.Contents {
+			key := aws.StringValue(obj.Key)
+			if !strings.HasSuffix(key, ".xml") || !strings.Contains(key, "junit") {
+				continue
+			}
+
+			// Format: test-results/<component>/<date>/<job-id>/<filename>
+			parts := strings.SplitN(key, "/", 5)
+			if len(parts) < 5 {
+				continue
+			}
+
+			dateStr := parts[2]
+			keyDate, err := time.Parse("2006-01-02", dateStr)
+			if err != nil || keyDate.Before(cutoff) {
+				continue
+			}
+
+			component := parts[1]
+			name, version, env := parseComponentPath(component)
+			gk := groupKey{name, version, env}
+
+			modified := aws.TimeValue(obj.LastModified)
+			existing, seen := newestByGroup[gk]
+			if !seen || modified.After(existing.modified) {
+				newestByGroup[gk] = &candidate{
+					key:       key,
+					component: component,
+					dateStr:   dateStr,
+					jobID:     parts[3],
+					modified:  modified,
+				}
+			}
+		}
+		return true
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list S3 objects: %w", err)
+	}
+
+	log.Printf("Deliverable collector: %d unique (name, version, env) groups to download", len(newestByGroup))
+
+	// Phase 2: fan out downloads with a worker pool.
+	candidates := make([]*candidate, 0, len(newestByGroup))
+	groupKeys := make([]groupKey, 0, len(newestByGroup))
+	for gk, cand := range newestByGroup {
+		candidates = append(candidates, cand)
+		groupKeys = append(groupKeys, gk)
+	}
+
+	results := make([]*downloadResult, len(candidates))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, downloadWorkers)
+
+	for i, cand := range candidates {
+		wg.Add(1)
+		go func(i int, cand *candidate, gk groupKey) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			suite, ts, err := c.downloadAndParseJUnit(cand.key)
+			if err != nil {
+				log.Printf("Warning: skipping %s: %v", cand.key, err)
+				return
+			}
+
+			parts := strings.SplitN(cand.key, "/", 5)
+			s3Dir := strings.Join(parts[:4], "/")
+
+			_, version, _ := parseComponentPath(cand.component)
+
+			env := gk.env
+			if env == "unknown" {
+				if detected := c.fetchEnvFromLog(gk.name, parts[2], parts[3]); detected != "" {
+					env = detected
+				}
+			}
+
+			results[i] = &downloadResult{
+				name:    gk.name,
+				version: version,
+				env:     env,
+				jobID:   cand.jobID,
+				s3Dir:   s3Dir,
+				key:     cand.key,
+				suite:   suite,
+				ts:      ts,
+			}
+		}(i, cand, groupKeys[i])
+	}
+	wg.Wait()
+
+	// Phase 3: build the index.
+	index := make(map[string]*models.DeliverableStatus)
+	for _, r := range results {
+		if r == nil {
+			continue
+		}
+
+		status := suiteStatus(r.suite)
+		logURL := s3URL(c.bucket, r.s3Dir+"/test_output.log")
+		junitURL := junitURL(c.bucket, r.key)
+
+		indexKey := r.name
+		op, exists := index[indexKey]
+		if !exists {
+			op = &models.DeliverableStatus{
+				Name:    r.name,
+				Version: r.version,
+				Results: make(map[string]*models.EnvironmentResult),
+			}
+			index[indexKey] = op
+		}
+
+		failedTests := extractFailedTests(r.suite)
+
+		op.Results[r.env] = &models.EnvironmentResult{
+			Status:      status,
+			Version:     r.version,
+			Total:       r.suite.Tests,
+			Passed:      r.suite.Tests - r.suite.Failures - r.suite.Errors - r.suite.Skipped,
+			Failed:      r.suite.Failures,
+			Skipped:     r.suite.Skipped,
+			Errors:      r.suite.Errors,
+			LastRun:     r.ts,
+			JobID:       r.jobID,
+			LogURL:      logURL,
+			JUnitURL:    junitURL,
+			FailedTests: failedTests,
+		}
+
+		if r.ts.After(op.LastUpdated) {
+			op.LastUpdated = r.ts
+		}
+	}
+
+	result := make([]models.DeliverableStatus, 0, len(index))
+	for _, op := range index {
+		result = append(result, *op)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return result[i].Version < result[j].Version
+	})
+
+	log.Printf("Collected deliverable status for %d operator+version combinations", len(result))
+	return result, nil
+}
+
+// adHocImageRegex extracts the image tag from AdHocTestImages in two formats:
+//  1. "Successfully added property[AdHocTestImages] - quay.io/.../operator-e2e:c7fabd7"
+//  2. "--properties AdHocTestImages:quay.io/.../operator-e2e:ec3ce7b" (rosa CLI args)
+var adHocImageRegex = regexp.MustCompile(`AdHocTestImages[:\]] ?-? ?\S+:(\S+?)[ "]`)
+
+// fetchMetaFromLog reads test_output.log and extracts both the environment
+// ("Will load config <env>") and the image tag from the AdHocTestImages property line.
+func (c *DeliverableCollector) fetchMetaFromLog(name, date, jobID string) (env, version string) {
+	logKey := fmt.Sprintf("test-results/%s/%s/%s/test_output.log", name, date, jobID)
+	output, err := c.s3Client.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(c.bucket),
+		Key:    aws.String(logKey),
+	})
+	if err != nil {
+		return "", ""
+	}
+	defer output.Body.Close()
+
+	buf := make([]byte, 16384) // 16KB — enough for the header lines
+	n, _ := output.Body.Read(buf)
+	content := string(buf[:n])
+
+	for _, e := range []string{"stage", "prod", "int"} {
+		if strings.Contains(content, "Will load config "+e) {
+			env = e
+			break
+		}
+	}
+
+	if m := adHocImageRegex.FindStringSubmatch(content); len(m) == 2 {
+		version = strings.TrimSpace(m[1])
+	}
+
+	return env, version
+}
+
+// fetchEnvFromLog is kept for callers that only need the environment.
+func (c *DeliverableCollector) fetchEnvFromLog(name, date, jobID string) string {
+	env, _ := c.fetchMetaFromLog(name, date, jobID)
+	return env
+}
+
+// downloadAndParseJUnit fetches and parses a JUnit XML from S3.
+func (c *DeliverableCollector) downloadAndParseJUnit(key string) (*JUnitTestSuite, time.Time, error) {
+	output, err := c.s3Client.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(c.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("GetObject failed: %w", err)
+	}
+	defer output.Body.Close()
+
+	data, err := io.ReadAll(output.Body)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("read failed: %w", err)
+	}
+
+	suite, err := parseJUnitData(data)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	ts := parseTimestamp(suite.Timestamp)
+
+	return suite, ts, nil
+}
+
+// extractFailedTests pulls failed/errored test case names and messages from a suite.
+func extractFailedTests(suite *JUnitTestSuite) []models.FailedTestCase {
+	var out []models.FailedTestCase
+	for _, tc := range suite.TestCases {
+		var msg string
+		if tc.Failure != nil {
+			msg = *tc.Failure
+		} else if tc.Error != nil {
+			msg = *tc.Error
+		} else {
+			continue
+		}
+		if len(msg) > 600 {
+			msg = msg[:600] + "…"
+		}
+		out = append(out, models.FailedTestCase{Name: tc.Name, Message: msg})
+	}
+	return out
+}
+
+// CollectPipelineHistory scans all S3 runs for a named operator and returns every
+// (version, env, date, jobID) tuple found, sorted newest first.
+func (c *DeliverableCollector) CollectPipelineHistory(operatorName string) (*models.PipelineHistory, error) {
+	prefix := "test-results/"
+
+	type runKey struct {
+		component string
+		dateStr   string
+		jobID     string
+	}
+	seen := make(map[runKey]bool)
+	var candidates []runKey
+
+	input := &s3.ListObjectsV2Input{
+		Bucket: aws.String(c.bucket),
+		Prefix: aws.String(prefix),
+	}
+
+	err := c.s3Client.ListObjectsV2Pages(input, func(page *s3.ListObjectsV2Output, _ bool) bool {
+		for _, obj := range page.Contents {
+			key := aws.StringValue(obj.Key)
+			if !strings.HasSuffix(key, ".xml") || !strings.Contains(key, "junit") {
+				continue
+			}
+			parts := strings.SplitN(key, "/", 5)
+			if len(parts) < 5 {
+				continue
+			}
+			component := parts[1]
+			name, _, _ := parseComponentPath(component)
+			if name != operatorName {
+				continue
+			}
+			rk := runKey{component: component, dateStr: parts[2], jobID: parts[3]}
+			if !seen[rk] {
+				seen[rk] = true
+				candidates = append(candidates, rk)
+			}
+		}
+		return true
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list S3 objects: %w", err)
+	}
+
+	// Fan-out: download each unique run in parallel
+	type rawRun struct {
+		version string
+		env     string
+		dateStr string
+		jobID   string
+		s3Dir   string
+		key     string
+		suite   *JUnitTestSuite
+		ts      time.Time
+	}
+
+	rawRuns := make([]*rawRun, len(candidates))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, downloadWorkers)
+
+	for i, rk := range candidates {
+		wg.Add(1)
+		go func(i int, rk runKey) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			// Find the JUnit XML key for this run
+			listOut, err := c.s3Client.ListObjectsV2(&s3.ListObjectsV2Input{
+				Bucket: aws.String(c.bucket),
+				Prefix: aws.String(fmt.Sprintf("test-results/%s/%s/%s/", rk.component, rk.dateStr, rk.jobID)),
+			})
+			if err != nil {
+				return
+			}
+			var junitKey string
+			for _, obj := range listOut.Contents {
+				k := aws.StringValue(obj.Key)
+				if strings.HasSuffix(k, ".xml") && strings.Contains(k, "junit") {
+					junitKey = k
+					break
+				}
+			}
+			if junitKey == "" {
+				return
+			}
+
+			suite, ts, err := c.downloadAndParseJUnit(junitKey)
+			if err != nil {
+				log.Printf("Warning: history skip %s: %v", junitKey, err)
+				return
+			}
+
+			_, version, env := parseComponentPath(rk.component)
+			if env == "unknown" {
+				if detected := c.fetchEnvFromLog(operatorName, rk.dateStr, rk.jobID); detected != "" {
+					env = detected
+				}
+			}
+
+			s3Dir := fmt.Sprintf("test-results/%s/%s/%s", rk.component, rk.dateStr, rk.jobID)
+			rawRuns[i] = &rawRun{
+				version: version,
+				env:     env,
+				dateStr: rk.dateStr,
+				jobID:   rk.jobID,
+				s3Dir:   s3Dir,
+				key:     junitKey,
+				suite:   suite,
+				ts:      ts,
+			}
+		}(i, rk)
+	}
+	wg.Wait()
+
+	var runs []models.PipelineRun
+	for _, r := range rawRuns {
+		if r == nil {
+			continue
+		}
+		runs = append(runs, models.PipelineRun{
+			Version:  r.version,
+			Env:      r.env,
+			Status:   suiteStatus(r.suite),
+			Date:     r.dateStr,
+			JobID:    r.jobID,
+			LastRun:  r.ts,
+			LogURL:   s3URL(c.bucket, r.s3Dir+"/test_output.log"),
+			JUnitURL: junitURL(c.bucket, r.key),
+			Failed:   extractFailedTests(r.suite),
+			Total:    r.suite.Tests,
+			Passed:   r.suite.Tests - r.suite.Failures - r.suite.Errors - r.suite.Skipped,
+		})
+	}
+
+	// Sort newest first
+	sort.Slice(runs, func(i, j int) bool {
+		return runs[i].LastRun.After(runs[j].LastRun)
+	})
+
+	return &models.PipelineHistory{
+		Name: operatorName,
+		Runs:         runs,
+	}, nil
+}
+

--- a/pkg/dashboard/collectors/helpers.go
+++ b/pkg/dashboard/collectors/helpers.go
@@ -29,11 +29,11 @@ func parseTimestamp(ts string) time.Time {
 }
 
 // s3URL returns a dashboard proxy URL that streams the S3 object through the server.
-func s3URL(bucket, key string) string {
+func s3URL(_, key string) string {
 	return "/dashboard/s3?key=" + url.QueryEscape(key)
 }
 
 // junitURL returns a dashboard URL that fetches the JUnit XML from S3 and renders it as HTML.
-func junitURL(bucket, key string) string {
+func junitURL(_, key string) string {
 	return "/dashboard/junit?key=" + url.QueryEscape(key)
 }

--- a/pkg/dashboard/collectors/helpers.go
+++ b/pkg/dashboard/collectors/helpers.go
@@ -1,0 +1,39 @@
+package collectors
+
+import (
+	"net/url"
+	"time"
+)
+
+// suiteStatus returns "passed", "failed", or "error" based on a parsed JUnit suite.
+func suiteStatus(suite *JUnitTestSuite) string {
+	if suite.Failures > 0 {
+		return "failed"
+	}
+	if suite.Errors > 0 {
+		return "error"
+	}
+	return "passed"
+}
+
+// parseTimestamp parses a JUnit timestamp string, returning zero time on failure.
+// Callers should apply their own fallback (e.g. S3 LastModified) for zero results.
+func parseTimestamp(ts string) time.Time {
+	if t, err := time.Parse("2006-01-02T15:04:05", ts); err == nil {
+		return t
+	}
+	if t, err := time.Parse(time.RFC3339, ts); err == nil {
+		return t
+	}
+	return time.Time{}
+}
+
+// s3URL returns a dashboard proxy URL that streams the S3 object through the server.
+func s3URL(bucket, key string) string {
+	return "/dashboard/s3?key=" + url.QueryEscape(key)
+}
+
+// junitURL returns a dashboard URL that fetches the JUnit XML from S3 and renders it as HTML.
+func junitURL(bucket, key string) string {
+	return "/dashboard/junit?key=" + url.QueryEscape(key)
+}

--- a/pkg/dashboard/collectors/reserves.go
+++ b/pkg/dashboard/collectors/reserves.go
@@ -1,0 +1,130 @@
+package collectors
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osde2e/pkg/common/clusterproperties"
+	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
+	"github.com/openshift/osde2e/pkg/dashboard/models"
+)
+
+// ReserveCollector collects cluster reserve information from one or more OCM environments.
+type ReserveCollector struct {
+	providers map[string]*ocmprovider.OCMProvider
+}
+
+// NewReserveCollector creates a new reserve collector for the given OCM environments.
+func NewReserveCollector(envs ...string) (*ReserveCollector, error) {
+	providers := make(map[string]*ocmprovider.OCMProvider, len(envs))
+	for _, env := range envs {
+		p, err := ocmprovider.NewWithEnv(env)
+		if err != nil {
+			log.Printf("Warning: could not create provider for environment %s: %v (skipping)", env, err)
+			continue
+		}
+		providers[env] = p
+	}
+	if len(providers) == 0 {
+		return nil, fmt.Errorf("could not connect to any OCM environment")
+	}
+	return &ReserveCollector{providers: providers}, nil
+}
+
+// CollectReserves retrieves reserved clusters from all configured OCM environments.
+func (c *ReserveCollector) CollectReserves() ([]models.ClusterReserve, error) {
+	query := fmt.Sprintf(
+		"properties.MadeByOSDe2e='true' AND properties.Availability like '%s%%'",
+		clusterproperties.Reserved,
+	)
+
+	var all []models.ClusterReserve
+	for env, p := range c.providers {
+		resp, err := p.GetConnection().ClustersMgmt().V1().Clusters().List().
+			Search(query).
+			Size(500).
+			Send()
+		if err != nil {
+			if isAuthError(err) {
+				log.Printf("Info: skipping reserves for env %q (OCM account not available)", env)
+			} else {
+				log.Printf("Warning: failed to query reserved clusters for env %q: %v", env, err)
+			}
+			continue
+		}
+		resp.Items().Each(func(cluster *v1.Cluster) bool {
+			all = append(all, c.ocmClusterToReserve(cluster))
+			return true
+		})
+	}
+
+	log.Printf("Collected %d reserved clusters from OCM", len(all))
+	return all, nil
+}
+
+// ocmClusterToReserve converts an OCM cluster to a ClusterReserve model
+func (c *ReserveCollector) ocmClusterToReserve(cluster *v1.Cluster) models.ClusterReserve {
+	reserve := models.ClusterReserve{
+		ID:            cluster.ID(),
+		Name:          cluster.Name(),
+		State:         string(cluster.State()),
+		Version:       cluster.Version().ID(),
+		Region:        cluster.Region().ID(),
+		CloudProvider: cluster.CloudProvider().ID(),
+		CreatedAt:     cluster.CreationTimestamp(),
+		ExpiresAt:     cluster.ExpirationTimestamp(),
+		Product:       cluster.Product().ID(),
+		Properties:    make(map[string]string),
+	}
+
+	// Extract availability from properties
+	if props, ok := cluster.GetProperties(); ok {
+		for k, v := range props {
+			reserve.Properties[k] = v
+			if k == clusterproperties.Availability {
+				reserve.Availability = v
+			}
+		}
+	}
+
+	return reserve
+}
+
+// CollectClustersPerEnv returns all osde2e clusters grouped by environment name.
+func (c *ReserveCollector) CollectClustersPerEnv() (map[string][]models.ClusterReserve, error) {
+	result := make(map[string][]models.ClusterReserve)
+	for env, p := range c.providers {
+		resp, err := p.GetConnection().ClustersMgmt().V1().Clusters().List().
+			Search("properties.MadeByOSDe2e='true'").
+			Size(1000).
+			Send()
+		if err != nil {
+			if isAuthError(err) {
+				log.Printf("Info: skipping clusters for env %q (OCM account not available)", env)
+			} else {
+				log.Printf("Warning: failed to query clusters for env %q: %v", env, err)
+			}
+			continue
+		}
+		var clusters []models.ClusterReserve
+		resp.Items().Each(func(cluster *v1.Cluster) bool {
+			clusters = append(clusters, c.ocmClusterToReserve(cluster))
+			return true
+		})
+		result[env] = clusters
+	}
+	return result, nil
+}
+
+// CountExpiringSoon counts clusters expiring within the given threshold
+func (c *ReserveCollector) CountExpiringSoon(reserves []models.ClusterReserve, threshold time.Duration) int {
+	count := 0
+	for _, r := range reserves {
+		if r.IsExpiringSoon(threshold) {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/dashboard/collectors/s3tests.go
+++ b/pkg/dashboard/collectors/s3tests.go
@@ -1,0 +1,273 @@
+package collectors
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"log"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	awscommon "github.com/openshift/osde2e/pkg/common/aws"
+	"github.com/openshift/osde2e/pkg/dashboard/models"
+)
+
+// JUnitTestSuite represents a single <testsuite> element
+type JUnitTestSuite struct {
+	XMLName   xml.Name        `xml:"testsuite"`
+	Name      string          `xml:"name,attr"`
+	Tests     int             `xml:"tests,attr"`
+	Failures  int             `xml:"failures,attr"`
+	Errors    int             `xml:"errors,attr"`
+	Skipped   int             `xml:"skipped,attr"`
+	Time      float64         `xml:"time,attr"`
+	Timestamp string          `xml:"timestamp,attr"`
+	TestCases []JUnitTestCase `xml:"testcase"`
+}
+
+// jUnitTestSuites represents a <testsuites> wrapper (may contain multiple <testsuite> children)
+type jUnitTestSuites struct {
+	XMLName    xml.Name         `xml:"testsuites"`
+	Tests      int              `xml:"tests,attr"`
+	Failures   int              `xml:"failures,attr"`
+	Errors     int              `xml:"errors,attr"`
+	Time       float64          `xml:"time,attr"`
+	TestSuites []JUnitTestSuite `xml:"testsuite"`
+}
+
+// JUnitTestCase represents a single test case
+type JUnitTestCase struct {
+	Name      string  `xml:"name,attr"`
+	Classname string  `xml:"classname,attr"`
+	Time      float64 `xml:"time,attr"`
+	Failure   *string `xml:"failure,omitempty"`
+	Error     *string `xml:"error,omitempty"`
+	Skipped   *string `xml:"skipped,omitempty"`
+}
+
+// parseJUnitData parses raw JUnit XML bytes handling both <testsuite> and <testsuites> root elements.
+// When the root is <testsuites>, suites are merged into a single JUnitTestSuite by summing counters
+// and taking the timestamp from the first child suite.
+func parseJUnitData(data []byte) (*JUnitTestSuite, error) {
+	// Peek at the root element name
+	type rootPeek struct {
+		XMLName xml.Name
+	}
+	var peek rootPeek
+	if err := xml.Unmarshal(data, &peek); err != nil {
+		return nil, fmt.Errorf("failed to peek XML root: %w", err)
+	}
+
+	switch peek.XMLName.Local {
+	case "testsuite":
+		var suite JUnitTestSuite
+		if err := xml.Unmarshal(data, &suite); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal <testsuite>: %w", err)
+		}
+		return &suite, nil
+
+	case "testsuites":
+		var suites jUnitTestSuites
+		if err := xml.Unmarshal(data, &suites); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal <testsuites>: %w", err)
+		}
+		// Merge all child suites into one
+		merged := &JUnitTestSuite{Name: "merged"}
+		for _, s := range suites.TestSuites {
+			merged.Tests += s.Tests
+			merged.Failures += s.Failures
+			merged.Errors += s.Errors
+			merged.Skipped += s.Skipped
+			merged.Time += s.Time
+			merged.TestCases = append(merged.TestCases, s.TestCases...)
+			if merged.Timestamp == "" && s.Timestamp != "" {
+				merged.Timestamp = s.Timestamp
+				merged.Name = s.Name
+			}
+		}
+		return merged, nil
+
+	default:
+		return nil, fmt.Errorf("unexpected XML root element: <%s>", peek.XMLName.Local)
+	}
+}
+
+// TestResultsCollector collects test results from S3
+type TestResultsCollector struct {
+	s3Client *s3.S3
+	bucket   string
+	region   string
+}
+
+// NewTestResultsCollector creates a new test results collector using existing AWS session
+func NewTestResultsCollector(bucket, region string) (*TestResultsCollector, error) {
+	sess, err := awscommon.CcsAwsSession.GetSession()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AWS session: %w", err)
+	}
+
+	s3Client := s3.New(sess, aws.NewConfig().WithRegion(region))
+
+	return &TestResultsCollector{
+		s3Client: s3Client,
+		bucket:   bucket,
+		region:   region,
+	}, nil
+}
+
+// CollectRecentTests retrieves recent test results from S3
+func (c *TestResultsCollector) CollectRecentTests(maxResults int) ([]models.TestResult, error) {
+	// List objects in the test-results/ prefix
+	prefix := "test-results/"
+
+	input := &s3.ListObjectsV2Input{
+		Bucket: aws.String(c.bucket),
+		Prefix: aws.String(prefix),
+	}
+
+	var allResults []models.TestResult
+	resultsByJob := make(map[string]*models.TestResult)
+
+	err := c.s3Client.ListObjectsV2Pages(input, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
+		for _, obj := range page.Contents {
+			key := aws.StringValue(obj.Key)
+
+			// Skip if not a JUnit XML file
+			if !strings.HasSuffix(key, ".xml") || !strings.Contains(key, "junit") {
+				continue
+			}
+
+			// Parse the S3 key to extract metadata
+			// Format: test-results/<component>/<date>/<job-id>/junit*.xml
+			parts := strings.Split(key, "/")
+			if len(parts) < 4 {
+				continue
+			}
+
+			component := parts[1]
+			date := parts[2]
+			jobID := parts[3]
+
+			jobKey := fmt.Sprintf("%s-%s-%s", component, date, jobID)
+
+			// Only process if we haven't seen this job yet
+			if _, exists := resultsByJob[jobKey]; !exists {
+				result, err := c.parseJUnitXML(key, component, date, jobID)
+				if err != nil {
+					log.Printf("Warning: failed to parse %s: %v", key, err)
+					continue
+				}
+
+				resultsByJob[jobKey] = result
+			}
+		}
+
+		// Stop if we have enough results
+		return len(resultsByJob) < maxResults
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to list S3 objects: %w", err)
+	}
+
+	// Convert map to slice
+	for _, result := range resultsByJob {
+		allResults = append(allResults, *result)
+	}
+
+	// Sort by timestamp (most recent first)
+	sort.Slice(allResults, func(i, j int) bool {
+		return allResults[i].Timestamp.After(allResults[j].Timestamp)
+	})
+
+	// Limit results
+	if len(allResults) > maxResults {
+		allResults = allResults[:maxResults]
+	}
+
+	log.Printf("Collected %d test results from S3", len(allResults))
+	return allResults, nil
+}
+
+// parseJUnitXML downloads and parses a JUnit XML file from S3
+func (c *TestResultsCollector) parseJUnitXML(key, component, date, jobID string) (*models.TestResult, error) {
+	// Download the file
+	output, err := c.s3Client.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(c.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to download %s: %w", key, err)
+	}
+	defer output.Body.Close()
+
+	// Parse XML
+	data, err := io.ReadAll(output.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", key, err)
+	}
+
+	suite, err := parseJUnitData(data)
+	if err != nil {
+		return nil, err
+	}
+
+	timestamp := parseTimestamp(suite.Timestamp)
+
+	status := suiteStatus(suite)
+
+	// Build per-test-case list
+	testCases := make([]models.TestCase, 0, len(suite.TestCases))
+	for _, tc := range suite.TestCases {
+		tcStatus := "passed"
+		var msg string
+		if tc.Failure != nil {
+			tcStatus = "failed"
+			msg = *tc.Failure
+		} else if tc.Error != nil {
+			tcStatus = "error"
+			msg = *tc.Error
+		} else if tc.Skipped != nil {
+			tcStatus = "skipped"
+			msg = *tc.Skipped
+		}
+		// Trim long messages to 500 chars for the UI
+		if len(msg) > 500 {
+			msg = msg[:500] + "…"
+		}
+		testCases = append(testCases, models.TestCase{
+			Name:     tc.Name,
+			Duration: tc.Time,
+			Status:   tcStatus,
+			Message:  msg,
+		})
+	}
+
+	s3Path := path.Dir(key)
+	logURL := s3URL(c.bucket, path.Join(s3Path, "test_output.log"))
+	junitURL := junitURL(c.bucket, key)
+
+	return &models.TestResult{
+		JobID:        jobID,
+		JobName:      component,
+		Component:    component,
+		Date:         date,
+		Status:       status,
+		TotalTests:   suite.Tests,
+		PassedTests:  suite.Tests - suite.Failures - suite.Errors - suite.Skipped,
+		FailedTests:  suite.Failures,
+		ErrorTests:   suite.Errors,
+		SkippedTests: suite.Skipped,
+		Duration:     suite.Time,
+		S3Path:       s3Path,
+		LogURL:       logURL,
+		JUnitXMLURL:  junitURL,
+		Timestamp:    timestamp,
+		TestCases:    testCases,
+	}, nil
+}
+
+

--- a/pkg/dashboard/collectors/sqs.go
+++ b/pkg/dashboard/collectors/sqs.go
@@ -1,0 +1,359 @@
+package collectors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	awscommon "github.com/openshift/osde2e/pkg/common/aws"
+	"github.com/openshift/osde2e/pkg/dashboard/models"
+	"github.com/openshift/osde2e/pkg/dashboard/store"
+	"gopkg.in/yaml.v3"
+)
+
+// s3Event is the top-level SQS message body for S3 event notifications.
+type s3Event struct {
+	Records []struct {
+		S3 struct {
+			Bucket struct{ Name string } `json:"bucket"`
+			Object struct{ Key string }  `json:"object"`
+		} `json:"s3"`
+	} `json:"Records"`
+}
+
+// SQSConsumer polls an SQS queue for S3 ObjectCreated events and writes
+// parsed JUnit results into the Store.
+type SQSConsumer struct {
+	sqsClient *sqs.SQS
+	opCollect *DeliverableCollector
+	store     *store.Store
+	queueURL  string
+	bucket    string
+}
+
+// NewSQSConsumer creates a new consumer.
+func NewSQSConsumer(queueURL, bucket, region string, st *store.Store) (*SQSConsumer, error) {
+	opCollect, err := NewDeliverableCollector(bucket, region, 0)
+	if err != nil {
+		return nil, fmt.Errorf("create deliverable collector: %w", err)
+	}
+
+	sess, err := awscommon.CcsAwsSession.GetSession()
+	if err != nil {
+		return nil, fmt.Errorf("get AWS session: %w", err)
+	}
+
+	return &SQSConsumer{
+		sqsClient: sqs.New(sess),
+		opCollect: opCollect,
+		store:     st,
+		queueURL:  queueURL,
+		bucket:    bucket,
+	}, nil
+}
+
+// Run starts a long-poll loop that processes messages until ctx is cancelled.
+// Call in a goroutine: go consumer.Run(ctx)
+func (c *SQSConsumer) Run(ctx context.Context) {
+	log.Printf("SQS consumer: started, queue=%s", c.queueURL)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("SQS consumer: stopped")
+			return
+		default:
+		}
+
+		msgs, err := c.sqsClient.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
+			QueueUrl:            aws.String(c.queueURL),
+			MaxNumberOfMessages: aws.Int64(10),
+			WaitTimeSeconds:     aws.Int64(20), // long poll — blocks up to 20s if queue empty
+			VisibilityTimeout:   aws.Int64(60),
+		})
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Printf("SQS consumer: receive error: %v — retrying in 10s", err)
+			select {
+			case <-time.After(10 * time.Second):
+			case <-ctx.Done():
+				return
+			}
+			continue
+		}
+
+		for _, msg := range msgs.Messages {
+			if err := c.processMessage(aws.StringValue(msg.Body)); err != nil {
+				log.Printf("SQS consumer: process error: %v", err)
+				// Leave on queue — will become visible again after VisibilityTimeout.
+				continue
+			}
+			_, _ = c.sqsClient.DeleteMessage(&sqs.DeleteMessageInput{
+				QueueUrl:      aws.String(c.queueURL),
+				ReceiptHandle: msg.ReceiptHandle,
+			})
+		}
+	}
+}
+
+// processMessage parses one SQS message body (direct S3 event or SNS-wrapped).
+func (c *SQSConsumer) processMessage(body string) error {
+	// SNS wraps the S3 JSON event inside a "Message" string field.
+	var wrapper struct{ Message string }
+	raw := body
+	if err := json.Unmarshal([]byte(body), &wrapper); err == nil && wrapper.Message != "" {
+		raw = wrapper.Message
+	}
+
+	var event s3Event
+	if err := json.Unmarshal([]byte(raw), &event); err != nil {
+		return fmt.Errorf("unmarshal S3 event: %w", err)
+	}
+
+	var failed int
+	for _, rec := range event.Records {
+		if err := c.processKey(rec.S3.Bucket.Name, rec.S3.Object.Key); err != nil {
+			log.Printf("SQS consumer: skip %s: %v", rec.S3.Object.Key, err)
+			failed++
+		}
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d record(s) failed processing; message will be retried", failed)
+	}
+	return nil
+}
+
+// processKey downloads, parses, and stores the result for a single S3 JUnit key.
+// Expected key format: test-results/<component>/<date>/<job-id>/<file>.xml
+func (c *SQSConsumer) processKey(bucket, key string) error {
+	if !strings.HasSuffix(key, ".xml") || !strings.Contains(key, "junit") {
+		return nil
+	}
+
+	parts := strings.SplitN(key, "/", 5)
+	if len(parts) < 5 {
+		return fmt.Errorf("unexpected key format: %s", key)
+	}
+
+	component := parts[1]
+	dateStr := parts[2]
+	jobID := parts[3]
+
+	name, version, env := parseComponentPath(component)
+
+	// Always read the log to get env + image tag — these paths are unversioned
+	// so parseComponentPath returns "unknown" for both env and version.
+	logEnv, logVersion := c.opCollect.fetchMetaFromLog(name, dateStr, jobID)
+	if env == "unknown" && logEnv != "" {
+		env = logEnv
+	}
+	if version == "unknown" && logVersion != "" {
+		version = logVersion
+	}
+
+	suite, ts, err := c.opCollect.downloadAndParseJUnit(key)
+	if err != nil {
+		return fmt.Errorf("parse junit %s: %w", key, err)
+	}
+
+	status := suiteStatus(suite)
+
+	s3Dir := strings.Join(parts[:4], "/")
+
+	// Only fetch LLM analysis for failed runs — no point for passing ones.
+	var llm *models.LLMAnalysis
+	if status != "passed" {
+		llm = c.fetchLLMAnalysis(bucket, s3Dir)
+	}
+
+	rec := store.RunRecord{
+		Name: name,
+		Env:          env,
+		Version:      version,
+		Status:       status,
+		Passed:       suite.Tests - suite.Failures - suite.Errors - suite.Skipped,
+		Failed:       suite.Failures + suite.Errors,
+		Total:        suite.Tests,
+		JobID:        jobID,
+		Date:         dateStr,
+		LastRun:      ts,
+		LogURL:       s3URL(c.opCollect.bucket, s3Dir+"/test_output.log"),
+		JUnitURL:     junitURL(c.opCollect.bucket, key),
+		FailedTests:  extractFailedTests(suite),
+		LLMAnalysis:  llm,
+	}
+
+	if err := c.store.UpsertRun(rec); err != nil {
+		return fmt.Errorf("upsert: %w", err)
+	}
+
+	log.Printf("SQS consumer: stored %s %s %s → %s", name, version, env, status)
+	return nil
+}
+
+// summaryYAML mirrors the relevant fields of summary.yaml produced by the LLM analysis job.
+type summaryYAML struct {
+	Response string `yaml:"response"`
+	Status   string `yaml:"status"`
+}
+
+// llmResponse is the JSON embedded in the response field (may be wrapped in ```json ... ```).
+type llmResponse struct {
+	RootCause       string   `json:"root_cause"`
+	Recommendations []string `json:"recommendations"`
+}
+
+// reJSONBlock strips ```json ... ``` markdown fences if present.
+var reJSONBlock = regexp.MustCompile("(?s)```(?:json)?\\s*(\\{.*?\\})\\s*```")
+
+// fetchLLMAnalysis looks for a summary.yaml under the job's S3 prefix and parses it.
+// It tries both known path patterns:
+//  1. test-results/<op>/<date>/<jobID>/llm-analysis/summary.yaml
+//  2. test-results/<op>/<date>/<jobID>/install/*/llm-analysis/summary.yaml
+func (c *SQSConsumer) fetchLLMAnalysis(bucket, s3Dir string) *models.LLMAnalysis {
+	// Pattern 1: shallow path
+	candidates := []string{
+		s3Dir + "/llm-analysis/summary.yaml",
+	}
+
+	// Pattern 2: deep path — list install/* to find the e2e image subdirectory
+	listOut, err := c.opCollect.s3Client.ListObjectsV2(&s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+		Prefix: aws.String(s3Dir + "/install/"),
+	})
+	if err == nil {
+		for _, obj := range listOut.Contents {
+			key := aws.StringValue(obj.Key)
+			if strings.HasSuffix(key, "/llm-analysis/summary.yaml") {
+				candidates = append(candidates, key)
+			}
+		}
+	}
+
+	for _, key := range candidates {
+		out, err := c.opCollect.s3Client.GetObject(&s3.GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		if err != nil {
+			continue
+		}
+		data, err := io.ReadAll(out.Body)
+		out.Body.Close()
+		if err != nil {
+			continue
+		}
+
+		var sy summaryYAML
+		if err := yaml.Unmarshal(data, &sy); err != nil || sy.Response == "" {
+			continue
+		}
+
+		// Extract the JSON — may be bare or wrapped in ```json ... ```
+		raw := sy.Response
+		if m := reJSONBlock.FindStringSubmatch(raw); len(m) == 2 {
+			raw = m[1]
+		}
+
+		var resp llmResponse
+		if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &resp); err != nil {
+			log.Printf("fetchLLMAnalysis: parse response JSON from %s: %v", key, err)
+			continue
+		}
+
+		if resp.RootCause == "" {
+			continue
+		}
+
+		return &models.LLMAnalysis{
+			RootCause:       resp.RootCause,
+			Recommendations: resp.Recommendations,
+		}
+	}
+
+	return nil
+}
+
+// Backfill scans all historical S3 objects and populates the store from scratch.
+// Run once at first startup or when the DB is missing/corrupt.
+func (c *SQSConsumer) Backfill() error {
+	log.Printf("Backfill: scanning s3://%s/test-results/ ...", c.bucket)
+
+	// Collect unique (component, date, jobID) → best junit key
+	type runKey struct{ component, date, jobID string }
+	seen := make(map[runKey]string)
+
+	err := c.opCollect.s3Client.ListObjectsV2Pages(&s3.ListObjectsV2Input{
+		Bucket: aws.String(c.bucket),
+		Prefix: aws.String("test-results/"),
+	}, func(page *s3.ListObjectsV2Output, _ bool) bool {
+		for _, obj := range page.Contents {
+			key := aws.StringValue(obj.Key)
+			if !strings.HasSuffix(key, ".xml") || !strings.Contains(key, "junit") {
+				continue
+			}
+			parts := strings.SplitN(key, "/", 5)
+			if len(parts) < 5 {
+				continue
+			}
+			rk := runKey{parts[1], parts[2], parts[3]}
+			if _, exists := seen[rk]; !exists {
+				seen[rk] = key
+			}
+		}
+		return true
+	})
+	if err != nil {
+		return fmt.Errorf("list S3: %w", err)
+	}
+
+	log.Printf("Backfill: %d unique runs found — downloading in parallel...", len(seen))
+
+	// Fan out with the same worker pool size as the operator collector.
+	type work struct {
+		bucket, key string
+	}
+	jobs := make(chan work, len(seen))
+	for _, key := range seen {
+		jobs <- work{c.bucket, key}
+	}
+	close(jobs)
+
+	type result struct{ err error }
+	results := make(chan result, len(seen))
+
+	workers := downloadWorkers
+	if workers > len(seen) {
+		workers = len(seen)
+	}
+	for i := 0; i < workers; i++ {
+		go func() {
+			for j := range jobs {
+				err := c.processKey(j.bucket, j.key)
+				results <- result{err}
+			}
+		}()
+	}
+
+	ok, failed := 0, 0
+	for range seen {
+		r := <-results
+		if r.err != nil {
+			failed++
+		} else {
+			ok++
+		}
+	}
+
+	log.Printf("Backfill: complete. ok=%d failed=%d", ok, failed)
+	return nil
+}

--- a/pkg/dashboard/collectors/usage.go
+++ b/pkg/dashboard/collectors/usage.go
@@ -1,0 +1,154 @@
+package collectors
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osde2e/pkg/common/clusterproperties"
+	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
+	"github.com/openshift/osde2e/pkg/dashboard/models"
+)
+
+// UsageCollector collects cluster usage metrics from one or more OCM environments.
+type UsageCollector struct {
+	// providers maps environment name → OCMProvider for that env
+	providers map[string]*ocmprovider.OCMProvider
+}
+
+// NewUsageCollector creates a UsageCollector that queries the given OCM environments
+// in parallel. Each env must be a valid OCM environment name ("stage", "int", "prod", etc.).
+// Environments that fail to connect are skipped with a warning.
+func NewUsageCollector(envs ...string) (*UsageCollector, error) {
+	if len(envs) == 0 {
+		envs = []string{"stage", "int"}
+	}
+
+	providers := make(map[string]*ocmprovider.OCMProvider, len(envs))
+	for _, env := range envs {
+		p, err := ocmprovider.NewWithEnv(env)
+		if err != nil {
+			log.Printf("Warning: could not create provider for environment %s: %v (skipping)", env, err)
+			continue
+		}
+		providers[env] = p
+	}
+
+	if len(providers) == 0 {
+		return nil, fmt.Errorf("could not connect to any OCM environment")
+	}
+
+	return &UsageCollector{providers: providers}, nil
+}
+
+// CollectUsage queries all configured OCM environments in parallel and returns
+// one ClusterUsage entry per environment.
+func (c *UsageCollector) CollectUsage() ([]models.ClusterUsage, error) {
+	type result struct {
+		env   string
+		usage *models.ClusterUsage
+		err   error
+	}
+
+	ch := make(chan result, len(c.providers))
+	var wg sync.WaitGroup
+
+	for env, provider := range c.providers {
+		wg.Add(1)
+		go func(env string, p *ocmprovider.OCMProvider) {
+			defer wg.Done()
+			usage, err := collectUsageForEnv(env, p)
+			ch <- result{env: env, usage: usage, err: err}
+		}(env, provider)
+	}
+
+	wg.Wait()
+	close(ch)
+
+	var usages []models.ClusterUsage
+	for r := range ch {
+		if r.err != nil {
+			if isAuthError(r.err) {
+				log.Printf("Info: skipping env %q (OCM account not available in this environment)", r.env)
+			} else {
+				log.Printf("Warning: failed to collect usage for env %q: %v", r.env, r.err)
+			}
+			continue
+		}
+		usages = append(usages, *r.usage)
+	}
+
+	log.Printf("Collected usage metrics for %d environments", len(usages))
+	return usages, nil
+}
+
+// collectUsageForEnv queries a single OCM environment and returns its ClusterUsage.
+func collectUsageForEnv(env string, provider *ocmprovider.OCMProvider) (*models.ClusterUsage, error) {
+	query := "properties.MadeByOSDe2e='true'"
+
+	resp, err := provider.GetConnection().ClustersMgmt().V1().Clusters().List().
+		Search(query).
+		Size(1000).
+		Send()
+	if err != nil {
+		return nil, fmt.Errorf("failed to query clusters: %w", err)
+	}
+
+	usage := &models.ClusterUsage{
+		Environment:     env,
+		ByState:         make(map[string]int),
+		ByAvailability:  make(map[string]int),
+		ByCloudProvider: make(map[string]int),
+		ByVersion:       make(map[string]int),
+		LastUpdated:     time.Now(),
+	}
+
+	resp.Items().Each(func(cluster *v1.Cluster) bool {
+		usage.TotalClusters++
+		usage.ByState[string(cluster.State())]++
+		usage.ByCloudProvider[cluster.CloudProvider().ID()]++
+		usage.ByVersion[cluster.Version().ID()]++
+
+		if props, ok := cluster.GetProperties(); ok {
+			if avail, exists := props[clusterproperties.Availability]; exists {
+				usage.ByAvailability[avail]++
+			}
+		}
+
+		return true
+	})
+
+	return usage, nil
+}
+
+// CollectUsageByEnvironment retrieves usage for a specific environment.
+func (c *UsageCollector) CollectUsageByEnvironment(env string) (*models.ClusterUsage, error) {
+	p, ok := c.providers[env]
+	if !ok {
+		return &models.ClusterUsage{
+			Environment:     env,
+			ByState:         make(map[string]int),
+			ByAvailability:  make(map[string]int),
+			ByCloudProvider: make(map[string]int),
+			ByVersion:       make(map[string]int),
+			LastUpdated:     time.Now(),
+		}, nil
+	}
+	return collectUsageForEnv(env, p)
+}
+
+// isAuthError returns true for OCM errors that indicate the token is not valid
+// for a given environment (401, 403, 422 user-not-found). These are expected when
+// running with a stage/int token against prod, and should not be surfaced as warnings.
+func isAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "status is 401") ||
+		strings.Contains(msg, "status is 403") ||
+		(strings.Contains(msg, "status is 422") && strings.Contains(msg, "does not exist"))
+}

--- a/pkg/dashboard/server/server.go
+++ b/pkg/dashboard/server/server.go
@@ -1,0 +1,554 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awss3 "github.com/aws/aws-sdk-go/service/s3"
+	junit "github.com/joshdk/go-junit"
+	"github.com/openshift/osde2e/pkg/dashboard/collectors"
+	"github.com/openshift/osde2e/pkg/dashboard/config"
+	"github.com/openshift/osde2e/pkg/dashboard/handlers"
+	"github.com/openshift/osde2e/pkg/dashboard/models"
+	"github.com/openshift/osde2e/pkg/dashboard/store"
+)
+
+// Server represents the dashboard HTTP server
+type Server struct {
+	config              *config.Config
+	reserveCollector    *collectors.ReserveCollector
+	usageCollector      *collectors.UsageCollector
+	testResultCollector *collectors.TestResultsCollector
+	deliverableCollector *collectors.DeliverableCollector
+	store                *store.Store // optional; when set, deliverables/history served from DB
+	mux                 *http.ServeMux
+}
+
+// NewServer creates a new dashboard server instance
+func NewServer(cfg *config.Config) (*Server, error) {
+	// Initialize collectors
+	reserveCollector, err := collectors.NewReserveCollector(cfg.OCMEnvironments()...)
+	if err != nil {
+		log.Printf("Warning: Failed to initialize reserve collector: %v", err)
+		reserveCollector = nil
+	}
+
+	usageCollector, err := collectors.NewUsageCollector(cfg.OCMEnvironments()...)
+	if err != nil {
+		log.Printf("Warning: Failed to initialize usage collector: %v", err)
+		usageCollector = nil
+	}
+
+	var testResultCollector *collectors.TestResultsCollector
+	var deliverableCollector *collectors.DeliverableCollector
+	if cfg.S3Bucket != "" {
+		testResultCollector, err = collectors.NewTestResultsCollector(cfg.S3Bucket, cfg.S3Region)
+		if err != nil {
+			log.Printf("Warning: Failed to initialize test results collector: %v", err)
+			testResultCollector = nil
+		}
+
+		deliverableCollector, err = collectors.NewDeliverableCollector(cfg.S3Bucket, cfg.S3Region, cfg.LookbackDays)
+		if err != nil {
+			log.Printf("Warning: Failed to initialize deliverable status collector: %v", err)
+			deliverableCollector = nil
+		}
+	}
+
+	srv := &Server{
+		config:               cfg,
+		reserveCollector:     reserveCollector,
+		usageCollector:       usageCollector,
+		testResultCollector:  testResultCollector,
+		deliverableCollector: deliverableCollector,
+		mux:                  http.NewServeMux(),
+	}
+
+	// Setup routes
+	srv.setupRoutes()
+
+	return srv, nil
+}
+
+// setupRoutes configures all HTTP routes
+func (s *Server) setupRoutes() {
+	// HTML pages
+	s.mux.HandleFunc("/", s.handleRedirect)
+	s.mux.HandleFunc("/dashboard/usage", s.handleUsagePage)
+	s.mux.HandleFunc("/dashboard/pipelines", s.handleDeliverablesPage)
+	s.mux.HandleFunc("/dashboard/pipelines/", s.handlePipelineDetailPage)
+	s.mux.HandleFunc("/dashboard/analysis", s.handleAnalysisPage)
+
+	// API endpoints
+	s.mux.HandleFunc("/api/v1/reserves", s.handleReservesAPI)
+	s.mux.HandleFunc("/api/v1/usage", s.handleUsageAPI)
+	s.mux.HandleFunc("/api/v1/overview", s.handleOverviewAPI)
+	s.mux.HandleFunc("/api/v1/deliverables", s.handleDeliverablesAPI)
+
+	// S3 object proxy (streams objects server-side, no presigned URL expiry)
+	s.mux.HandleFunc("/dashboard/s3", s.handleS3Proxy)
+
+	// JUnit XML viewer
+	s.mux.HandleFunc("/dashboard/junit", s.handleJUnitReport)
+
+	// Health check
+	s.mux.HandleFunc("/health", s.handleHealth)
+}
+
+// WithStore attaches a SQLite store to the server.
+// When set, the deliverables overview and pipeline-detail pages read from the DB
+// instead of making live S3 API calls.
+func (s *Server) WithStore(st *store.Store) {
+	s.store = st
+}
+
+// Start starts the HTTP server and blocks until ctx is cancelled, then shuts down gracefully.
+func (s *Server) Start(addr string, ctx context.Context) error {
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           s.mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		log.Printf("Shutting down dashboard server...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+
+	log.Printf("Starting server on %s", addr)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}
+
+// handleRedirect redirects root to /dashboard
+func (s *Server) handleRedirect(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/" || r.URL.Path == "/dashboard" {
+		http.Redirect(w, r, "/dashboard/pipelines", http.StatusMovedPermanently)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+
+// handleUsagePage serves the Clusters page — all osde2e clusters grouped by env.
+func (s *Server) handleUsagePage(w http.ResponseWriter, r *http.Request) {
+	// EnvOrder defines the display sequence of environments.
+	envOrder := []string{"int", "stage", "prod"}
+
+	type EnvClusters struct {
+		Env      string
+		Clusters []models.ClusterReserve
+	}
+
+	var envClusters []EnvClusters
+
+	if s.reserveCollector != nil {
+		byEnv, err := s.reserveCollector.CollectClustersPerEnv()
+		if err != nil {
+			log.Printf("Warning: Failed to collect clusters per env: %v", err)
+		} else {
+			for _, env := range envOrder {
+				if clusters, ok := byEnv[env]; ok {
+					envClusters = append(envClusters, EnvClusters{Env: env, Clusters: clusters})
+				}
+			}
+		}
+	}
+
+	data := map[string]interface{}{
+		"ActivePage":  "usage",
+		"EnvClusters": envClusters,
+	}
+
+	s.renderTemplate(w, "usage.html", data)
+}
+
+// API Handlers
+
+// handleReservesAPI returns cluster reserves as JSON
+func (s *Server) handleReservesAPI(w http.ResponseWriter, r *http.Request) {
+	if s.reserveCollector == nil {
+		s.sendAPIError(w, "Reserve collector not initialized", http.StatusServiceUnavailable)
+		return
+	}
+
+	reserves, err := s.reserveCollector.CollectReserves()
+	if err != nil {
+		s.sendAPIError(w, fmt.Sprintf("Failed to collect reserves: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	s.sendAPISuccess(w, reserves)
+}
+
+// handleUsageAPI returns cluster usage metrics as JSON
+func (s *Server) handleUsageAPI(w http.ResponseWriter, r *http.Request) {
+	if s.usageCollector == nil {
+		s.sendAPIError(w, "Usage collector not initialized", http.StatusServiceUnavailable)
+		return
+	}
+
+	env := r.URL.Query().Get("environment")
+	if env != "" {
+		usage, err := s.usageCollector.CollectUsageByEnvironment(env)
+		if err != nil {
+			s.sendAPIError(w, fmt.Sprintf("Failed to collect usage: %v", err), http.StatusInternalServerError)
+			return
+		}
+		s.sendAPISuccess(w, usage)
+		return
+	}
+
+	usage, err := s.usageCollector.CollectUsage()
+	if err != nil {
+		s.sendAPIError(w, fmt.Sprintf("Failed to collect usage: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	s.sendAPISuccess(w, usage)
+}
+
+// handleDeliverablesPage serves the deliverables pipeline status HTML page.
+// When a Store is configured it reads from SQLite (<1ms); otherwise falls back
+// to a live S3 scan (slow, legacy path).
+func (s *Server) handleDeliverablesPage(w http.ResponseWriter, r *http.Request) {
+	var deliverables []models.DeliverableStatus
+
+	if s.store != nil {
+		// Fast path: DB read
+		result, err := s.store.GetLatest()
+		if err != nil {
+			log.Printf("Warning: store.GetLatest: %v", err)
+			deliverables = []models.DeliverableStatus{}
+		} else {
+			deliverables = result
+		}
+	} else if s.deliverableCollector != nil {
+		// Slow path: live S3 scan
+		collected, err := s.deliverableCollector.CollectDeliverables()
+		if err != nil {
+			log.Printf("Warning: Failed to collect deliverable status: %v", err)
+			deliverables = []models.DeliverableStatus{}
+		} else {
+			deliverables = collected
+		}
+	} else {
+		deliverables = []models.DeliverableStatus{}
+	}
+
+	data := map[string]interface{}{
+		"ActivePage":   "deliverables",
+		"Deliverables":  deliverables,
+		"Environments": []string{"stage", "integration"},
+		"S3Bucket":     s.config.S3Bucket,
+	}
+
+	s.renderTemplate(w, "deliverables.html", data)
+}
+
+// handlePipelineDetailPage serves the per-deliverable pipeline history page.
+// URL: /dashboard/pipelines/<name>
+// When a Store is configured it reads from SQLite (<1ms); otherwise falls back
+// to a live S3 scan (slow, legacy path).
+func (s *Server) handlePipelineDetailPage(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimPrefix(r.URL.Path, "/dashboard/pipelines/")
+	name = strings.TrimSpace(name)
+	if name == "" {
+		http.Redirect(w, r, "/dashboard/pipelines", http.StatusSeeOther)
+		return
+	}
+
+	var history *models.PipelineHistory
+	var err error
+
+	if s.store != nil {
+		// Fast path: DB read
+		history, err = s.store.GetHistory(name)
+		if err != nil {
+			log.Printf("store.GetHistory %s: %v", name, err)
+			s.sendError(w, "Failed to load pipeline history", http.StatusInternalServerError)
+			return
+		}
+	} else if s.deliverableCollector != nil {
+		// Slow path: live S3 scan
+		history, err = s.deliverableCollector.CollectPipelineHistory(name)
+		if err != nil {
+			log.Printf("Failed to collect pipeline history for %s: %v", name, err)
+			s.sendError(w, "Failed to load pipeline history", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		history = &models.PipelineHistory{Name: name}
+	}
+
+	data := map[string]interface{}{
+		"ActivePage": "deliverables",
+		"History":    history,
+	}
+
+	s.renderTemplate(w, "pipeline-detail.html", data)
+}
+
+// handleAnalysisPage groups all failed runs by AI root cause and renders the analysis page.
+func (s *Server) handleAnalysisPage(w http.ResponseWriter, r *http.Request) {
+	var groups []models.FailureGroup
+
+	if s.store != nil {
+		var err error
+		groups, err = s.store.GetFailureGroups()
+		if err != nil {
+			log.Printf("Warning: GetFailureGroups: %v", err)
+			groups = []models.FailureGroup{}
+		}
+	}
+
+	data := map[string]interface{}{
+		"ActivePage": "analysis",
+		"Groups":     groups,
+	}
+
+	s.renderTemplate(w, "analysis.html", data)
+}
+
+// handleDeliverablesAPI returns deliverable status as JSON
+func (s *Server) handleDeliverablesAPI(w http.ResponseWriter, r *http.Request) {
+	if s.deliverableCollector == nil {
+		s.sendAPIError(w, "Deliverable collector not initialized (S3 bucket not configured)", http.StatusServiceUnavailable)
+		return
+	}
+
+	deliverables, err := s.deliverableCollector.CollectDeliverables()
+	if err != nil {
+		s.sendAPIError(w, fmt.Sprintf("Failed to collect deliverable status: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Optional ?name= filter
+	if nameFilter := r.URL.Query().Get("name"); nameFilter != "" {
+		filtered := deliverables[:0]
+		for _, op := range deliverables {
+			if op.Name == nameFilter {
+				filtered = append(filtered, op)
+			}
+		}
+		deliverables = filtered
+	}
+
+	s.sendAPISuccess(w, deliverables)
+}
+
+// handleOverviewAPI returns dashboard overview data
+func (s *Server) handleOverviewAPI(w http.ResponseWriter, r *http.Request) {
+	overview := s.collectOverview()
+	s.sendAPISuccess(w, overview)
+}
+
+// handleS3Proxy streams an S3 object through the server using its AWS credentials.
+// URL: /dashboard/s3?key=<s3-object-key>
+// This avoids presigned URL expiry — the server holds long-lived credentials.
+func (s *Server) handleS3Proxy(w http.ResponseWriter, r *http.Request) {
+	key := r.URL.Query().Get("key")
+	if key == "" {
+		http.Error(w, "missing key parameter", http.StatusBadRequest)
+		return
+	}
+	if s.deliverableCollector == nil {
+		http.Error(w, "S3 not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	s3Client, bucket := s.deliverableCollector.S3Client()
+	out, err := s3Client.GetObjectWithContext(r.Context(), &awss3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		log.Printf("handleS3Proxy: GetObject %s: %v", key, err)
+		http.Error(w, "Failed to fetch object from S3", http.StatusBadGateway)
+		return
+	}
+	defer out.Body.Close()
+
+	if ct := aws.StringValue(out.ContentType); ct != "" {
+		w.Header().Set("Content-Type", ct)
+	} else if strings.HasSuffix(key, ".log") {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	} else if strings.HasSuffix(key, ".xml") {
+		w.Header().Set("Content-Type", "application/xml")
+	}
+	_, _ = io.Copy(w, out.Body)
+}
+
+// handleJUnitReport fetches a JUnit XML from S3 and renders it as HTML.
+// URL: /dashboard/junit?key=<s3-object-key>
+func (s *Server) handleJUnitReport(w http.ResponseWriter, r *http.Request) {
+	key := r.URL.Query().Get("key")
+	if key == "" {
+		http.Error(w, "missing key parameter", http.StatusBadRequest)
+		return
+	}
+	if s.deliverableCollector == nil {
+		http.Error(w, "S3 not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	s3Client, bucket := s.deliverableCollector.S3Client()
+	out, err := s3Client.GetObjectWithContext(r.Context(), &awss3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		log.Printf("handleJUnitReport: GetObject %s: %v", key, err)
+		s.sendError(w, "Failed to fetch JUnit XML from S3", http.StatusBadGateway)
+		return
+	}
+	defer out.Body.Close()
+
+	suites, err := junit.IngestReader(out.Body)
+	if err != nil {
+		log.Printf("handleJUnitReport: parse error: %v", err)
+		s.sendError(w, "Failed to parse JUnit XML", http.StatusUnprocessableEntity)
+		return
+	}
+
+	s.renderTemplate(w, "junit-report.html", map[string]interface{}{
+		"ActivePage": "deliverables",
+		"Suites":     suites,
+	})
+}
+
+// handleHealth returns server health status
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	status := models.HealthStatus{
+		Status:       "ok",
+		Timestamp:    handlers.Now(),
+		OCMConnected: s.reserveCollector != nil,
+		S3Connected:  s.testResultCollector != nil,
+	}
+
+	if !status.OCMConnected || !status.S3Connected {
+		status.Status = "degraded"
+	}
+
+	s.sendJSON(w, status)
+}
+
+// Helper methods
+
+// collectOverview aggregates data from all collectors
+func (s *Server) collectOverview() *models.DashboardOverview {
+	overview := &models.DashboardOverview{
+		LastUpdated:         handlers.Now(),
+		RecentTests:         []models.TestResult{},
+		ClusterUsageSummary: []models.ClusterUsage{},
+	}
+
+	// Collect reserves
+	if s.reserveCollector != nil {
+		reserves, err := s.reserveCollector.CollectReserves()
+		if err != nil {
+			log.Printf("Warning: Failed to collect reserves: %v", err)
+		} else {
+			overview.TotalReservedClusters = len(reserves)
+			overview.ClustersExpiringSoon = s.reserveCollector.CountExpiringSoon(reserves, s.config.ExpirationWarningThreshold)
+		}
+	}
+
+	// Collect usage
+	if s.usageCollector != nil {
+		usage, err := s.usageCollector.CollectUsage()
+		if err != nil {
+			log.Printf("Warning: Failed to collect usage: %v", err)
+		} else {
+			overview.ClusterUsageSummary = usage
+		}
+	}
+
+	// Collect recent tests
+	if s.testResultCollector != nil {
+		tests, err := s.testResultCollector.CollectRecentTests(20) // Last 20 tests
+		if err != nil {
+			log.Printf("Warning: Failed to collect test results: %v", err)
+		} else {
+			overview.RecentTests = tests
+			overview.ActiveTests = countActiveTests(tests)
+			overview.OverallSuccessRate = calculateSuccessRate(tests)
+		}
+	}
+
+	return overview
+}
+
+// sendJSON sends a JSON response
+func (s *Server) sendJSON(w http.ResponseWriter, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		log.Printf("Error encoding JSON: %v", err)
+	}
+}
+
+// sendAPISuccess sends a successful API response
+func (s *Server) sendAPISuccess(w http.ResponseWriter, data interface{}) {
+	s.sendJSON(w, models.APIResponse{
+		Success: true,
+		Data:    data,
+	})
+}
+
+// sendAPIError sends an API error response
+func (s *Server) sendAPIError(w http.ResponseWriter, message string, statusCode int) {
+	w.WriteHeader(statusCode)
+	s.sendJSON(w, models.APIResponse{
+		Success: false,
+		Error:   message,
+	})
+}
+
+// sendError sends an error response
+func (s *Server) sendError(w http.ResponseWriter, message string, statusCode int) {
+	http.Error(w, message, statusCode)
+}
+
+// Helper functions
+
+func countActiveTests(tests []models.TestResult) int {
+	// For now, consider tests from the last hour as "active"
+	// This can be refined based on actual test execution patterns
+	count := 0
+	for _, test := range tests {
+		if handlers.Now().Sub(test.Timestamp).Hours() < 1 {
+			count++
+		}
+	}
+	return count
+}
+
+func calculateSuccessRate(tests []models.TestResult) float64 {
+	if len(tests) == 0 {
+		return 0
+	}
+
+	passed := 0
+	for _, test := range tests {
+		if test.Status == "passed" {
+			passed++
+		}
+	}
+
+	return float64(passed) / float64(len(tests)) * 100
+}

--- a/pkg/dashboard/server/templates.go
+++ b/pkg/dashboard/server/templates.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"bytes"
+	"embed"
+	"html/template"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+//go:embed templates/*.html
+var templateFS embed.FS
+
+var funcMap = template.FuncMap{
+	"now": time.Now,
+	// localTime converts a time.Time to local timezone, formatted as "2006-01-02 15:04 MST"
+	"localTime": func(t time.Time) string {
+		return t.Local().Format("2006-01-02 15:04 MST")
+	},
+	// localTimeShort formats as "2006-01-02 15:04" without timezone suffix
+	"localDate": func(t time.Time) string {
+		return t.Local().Format("2006-01-02")
+	},
+	// subtract returns a - b (used in templates for failed count = total - passed)
+	"subtract": func(a, b int) int {
+		return a - b
+	},
+	// add returns a + b (used in junit-report.html for aggregating totals)
+	"add": func(a, b int) int {
+		return a + b
+	},
+	// githubRepo normalises an operator name to its GitHub repo name by stripping
+	// job-variant suffixes like -e2e-master that are not part of the repo name.
+	"githubRepo": func(name string) string {
+		for _, suffix := range []string{"-e2e-master", "-e2e"} {
+			if idx := strings.Index(name, suffix); idx > 0 {
+				return name[:idx]
+			}
+		}
+		return name
+	},
+}
+
+// renderTemplate renders an HTML template with data.
+// Each call parses base.html + the requested page file as a fresh template set
+// so that {{define "content"}} blocks from different pages don't collide.
+func (s *Server) renderTemplate(w http.ResponseWriter, name string, data interface{}) {
+	tmpl, err := template.New("").Funcs(funcMap).ParseFS(templateFS,
+		"templates/base.html",
+		"templates/"+name,
+	)
+	if err != nil {
+		log.Printf("Error loading template %s: %v", name, err)
+		http.Error(w, "Template error", http.StatusInternalServerError)
+		return
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "base.html", data); err != nil {
+		log.Printf("Error rendering template %s: %v", name, err)
+		http.Error(w, "Template rendering error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = buf.WriteTo(w)
+}
+
+// PageData represents common data passed to all pages
+type PageData struct {
+	ActivePage string
+	Data       interface{}
+}

--- a/pkg/dashboard/server/templates/analysis.html
+++ b/pkg/dashboard/server/templates/analysis.html
@@ -1,0 +1,196 @@
+{{template "base.html" .}}
+
+{{define "title"}}Delivery Dashboard - Analysis{{end}}
+
+{{define "extra-css"}}
+<style>
+    .group-card {
+        background: white;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+        margin-bottom: 1.5rem;
+        overflow: hidden;
+        border-left: 4px solid #e74c3c;
+    }
+
+    .group-header {
+        padding: 1rem 1.25rem 0.75rem;
+        border-bottom: 1px solid #f0f0f0;
+    }
+
+    .group-count {
+        display: inline-block;
+        background: #e74c3c;
+        color: white;
+        font-size: 0.72rem;
+        font-weight: 700;
+        padding: 0.15rem 0.5rem;
+        border-radius: 10px;
+        margin-bottom: 0.5rem;
+    }
+
+    .root-cause {
+        font-size: 0.9rem;
+        color: #222;
+        line-height: 1.5;
+        margin-bottom: 0.5rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+        cursor: default;
+    }
+
+    .recs {
+        font-size: 0.8rem;
+        color: #555;
+        margin-top: 0.5rem;
+    }
+
+    .recs ol {
+        margin: 0.25rem 0 0 1.2rem;
+        padding: 0;
+    }
+
+    .recs li { margin-bottom: 0.2rem; }
+
+    .entries-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.83rem;
+    }
+
+    .entries-table th {
+        background: #fafafa;
+        font-weight: 600;
+        color: #666;
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        padding: 0.5rem 1.25rem;
+        text-align: left;
+        border-bottom: 1px solid #f0f0f0;
+    }
+
+    .entries-table td {
+        padding: 0.5rem 1.25rem;
+        border-bottom: 1px solid #f8f8f8;
+        vertical-align: middle;
+    }
+
+    .entries-table tr:last-child td { border-bottom: none; }
+    .entries-table tr:hover td { background: #fafafa; }
+
+    .deliverable-link {
+        color: #0066cc;
+        font-weight: 500;
+        text-decoration: none;
+    }
+    .deliverable-link:hover { text-decoration: underline; }
+
+    code.ver {
+        font-size: 0.78rem;
+        background: #f0f0f0;
+        padding: 0.1rem 0.35rem;
+        border-radius: 3px;
+        font-family: monospace;
+    }
+
+    .env-chip {
+        display: inline-block;
+        padding: 0.1rem 0.45rem;
+        border-radius: 8px;
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+    }
+
+    .env-int   { background: #d1ecf1; color: #0c5460; }
+    .env-stage { background: #fff3cd; color: #856404; }
+    .env-prod  { background: #d4edda; color: #155724; }
+    .env-other { background: #e2e3e5; color: #555; }
+
+    .datetime { color: #777; font-size: 0.8rem; white-space: nowrap; }
+
+    .empty-analysis {
+        text-align: center;
+        padding: 4rem 2rem;
+        color: #888;
+    }
+</style>
+{{end}}
+
+{{define "content"}}
+<h1 style="margin-bottom: 0.25rem;">Analysis</h1>
+<p class="text-muted" style="margin-bottom: 1.5rem;">
+    Failed deliverables grouped by AI-identified root cause — most widespread failures first.
+    Click a deliverable name to see its full pipeline history.
+</p>
+
+{{if gt (len .Groups) 0}}
+    {{range $gi, $group := .Groups}}
+    <div class="group-card">
+        <div class="group-header">
+            <div class="group-count">{{len $group.Entries}} matching</div>
+            <div class="root-cause" title="{{$group.FailureMatch}}">{{$group.FailureMatch}}</div>
+            {{if $group.RootCause}}
+            <div class="recs" style="margin-top:0.6rem;">
+                <strong style="color:#444;">AI Analysis:</strong> {{$group.RootCause}}
+                {{if gt (len $group.Recommendations) 0}}
+                <ol style="margin-top:0.3rem;">{{range $group.Recommendations}}<li>{{.}}</li>{{end}}</ol>
+                {{end}}
+            </div>
+            {{end}}
+        </div>
+
+        <table class="entries-table">
+            <thead>
+                <tr>
+                    <th>Deliverable</th>
+                    <th>Version</th>
+                    <th>Env</th>
+                    <th>When</th>
+                    <th>Logs</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range $group.Entries}}
+                <tr>
+                    <td>
+                        <a class="deliverable-link" href="/dashboard/pipelines/{{.Name}}">
+                            {{.Name}}
+                        </a>
+                    </td>
+                    <td><code class="ver">{{.Version}}</code></td>
+                    <td>
+                        {{if eq .Env "int"}}
+                            <span class="env-chip env-int">int</span>
+                        {{else if eq .Env "stage"}}
+                            <span class="env-chip env-stage">stage</span>
+                        {{else if eq .Env "prod"}}
+                            <span class="env-chip env-prod">prod</span>
+                        {{else}}
+                            <span class="env-chip env-other">{{.Env}}</span>
+                        {{end}}
+                    </td>
+                    <td class="datetime">{{localTime .LastRun}}</td>
+                    <td>
+                        {{if .LogURL}}
+                            <a href="{{.LogURL}}" target="_blank" style="font-size:0.8rem;">Logs</a>
+                        {{else}}
+                            <span class="text-muted">—</span>
+                        {{end}}
+                    </td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+    {{end}}
+{{else}}
+<div class="empty-analysis">
+    <p style="font-size:1.1rem; margin-bottom:0.5rem;">No failure patterns found</p>
+    <p class="text-muted">AI analysis will appear here once failed runs with summary.yaml are backfilled.</p>
+</div>
+{{end}}
+{{end}}

--- a/pkg/dashboard/server/templates/base.html
+++ b/pkg/dashboard/server/templates/base.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{block "title" .}}Delivery Dashboard{{end}}</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: #f5f5f5;
+            color: #333;
+            line-height: 1.6;
+        }
+
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+            padding: 0 20px;
+        }
+
+        /* Header */
+        header {
+            background: #1a1a1a;
+            color: white;
+            padding: 1rem 0;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+
+        header .container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        header h1 {
+            font-size: 1.5rem;
+            font-weight: 600;
+        }
+
+        nav {
+            display: flex;
+            gap: 2rem;
+        }
+
+        nav a {
+            color: white;
+            text-decoration: none;
+            padding: 0.5rem 1rem;
+            border-radius: 4px;
+            transition: background 0.2s;
+        }
+
+        nav a:hover, nav a.active {
+            background: #333;
+        }
+
+        /* Main content */
+        main {
+            padding: 2rem 0;
+            min-height: calc(100vh - 200px);
+        }
+
+        /* Cards */
+        .card {
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            padding: 1.5rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #1a1a1a;
+        }
+
+        /* Stats grid */
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .stat-card {
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            padding: 1.5rem;
+            text-align: center;
+        }
+
+        .stat-card .value {
+            font-size: 2.5rem;
+            font-weight: bold;
+            color: #0066cc;
+            margin-bottom: 0.5rem;
+        }
+
+        .stat-card .label {
+            font-size: 0.9rem;
+            color: #666;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        /* Table */
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        th, td {
+            padding: 0.75rem;
+            text-align: left;
+            border-bottom: 1px solid #e0e0e0;
+        }
+
+        th {
+            background: #f8f8f8;
+            font-weight: 600;
+            color: #333;
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        tr:hover {
+            background: #f9f9f9;
+        }
+
+        /* Status badges */
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 12px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .badge.success {
+            background: #d4edda;
+            color: #155724;
+        }
+
+        .badge.danger {
+            background: #f8d7da;
+            color: #721c24;
+        }
+
+        .badge.warning {
+            background: #fff3cd;
+            color: #856404;
+        }
+
+        .badge.info {
+            background: #d1ecf1;
+            color: #0c5460;
+        }
+
+        .badge.secondary {
+            background: #e2e3e5;
+            color: #383d41;
+        }
+
+        /* Links */
+        a {
+            color: #0066cc;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        /* Footer */
+        footer {
+            background: #1a1a1a;
+            color: white;
+            text-align: center;
+            padding: 1.5rem 0;
+            margin-top: 3rem;
+        }
+
+        footer p {
+            font-size: 0.875rem;
+            color: #999;
+        }
+
+        /* JUnit report dialog */
+        dialog {
+            border: none;
+            border-radius: 8px;
+            box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+            padding: 1.5rem;
+            width: min(700px, 95vw);
+            max-height: 80vh;
+            overflow-y: auto;
+        }
+
+        dialog::backdrop {
+            background: rgba(0,0,0,0.35);
+        }
+
+        /* Empty state */
+        .empty-state {
+            text-align: center;
+            padding: 3rem;
+            color: #666;
+        }
+
+        .empty-state svg {
+            width: 64px;
+            height: 64px;
+            margin-bottom: 1rem;
+            opacity: 0.3;
+        }
+
+        /* Loading spinner */
+        .spinner {
+            border: 3px solid #f3f3f3;
+            border-top: 3px solid #0066cc;
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            animation: spin 1s linear infinite;
+            margin: 2rem auto;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
+        /* Utilities */
+        .text-muted {
+            color: #666;
+            font-size: 0.875rem;
+        }
+
+        .text-center {
+            text-align: center;
+        }
+
+        .mb-2 {
+            margin-bottom: 1rem;
+        }
+
+        .mt-2 {
+            margin-top: 1rem;
+        }
+    </style>
+    {{block "extra-css" .}}{{end}}
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Delivery Dashboard</h1>
+            <nav>
+                <a href="/dashboard/pipelines" {{if eq .ActivePage "deliverables"}}class="active"{{end}}>Pipelines</a>
+                <a href="/dashboard/analysis" {{if eq .ActivePage "analysis"}}class="active"{{end}}>Analysis</a>
+                <a href="/dashboard/usage" {{if eq .ActivePage "usage"}}class="active"{{end}}>Infra</a>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <div class="container">
+            {{block "content" .}}{{end}}
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2026 Delivery Dashboard | JIRA: SDCICD-1823</p>
+        </div>
+    </footer>
+
+    {{block "extra-js" .}}{{end}}
+    <script>
+    document.addEventListener('click', function(e) {
+        if (e.target.tagName === 'DIALOG') e.target.close();
+    });
+    </script>
+</body>
+</html>

--- a/pkg/dashboard/server/templates/deliverables.html
+++ b/pkg/dashboard/server/templates/deliverables.html
@@ -1,0 +1,417 @@
+{{template "base.html" .}}
+
+{{define "title"}}Delivery Dashboard - Pipelines{{end}}
+
+
+{{define "extra-css"}}
+<style>
+    .filter-bar {
+        display: flex;
+        gap: 1rem;
+        align-items: center;
+        margin-bottom: 1.5rem;
+    }
+
+    .filter-bar input {
+        padding: 0.5rem 0.75rem;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        font-size: 0.9rem;
+        width: 300px;
+    }
+
+    .filter-bar label {
+        font-size: 0.875rem;
+        color: #666;
+    }
+
+    th[data-sort] {
+        cursor: pointer;
+        user-select: none;
+    }
+
+    th[data-sort]:hover { background: #ebebeb; }
+    th[data-sort]::after { content: ' ⇅'; opacity: 0.4; font-size: 0.75rem; }
+    th[data-sort].asc::after  { content: ' ↑'; opacity: 1; }
+    th[data-sort].desc::after { content: ' ↓'; opacity: 1; }
+
+    /* Clickable operator rows */
+    tr.op-row {
+        cursor: pointer;
+        transition: background 0.1s;
+    }
+    tr.op-row:hover { background: #eef4ff; }
+    tr.op-row td.name-cell {
+        color: #0066cc;
+        font-weight: 500;
+    }
+
+    .status-cell {
+        text-align: center;
+        min-width: 130px;
+    }
+
+    .env-badge {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2px;
+        cursor: pointer;
+        padding: 0.3rem 0.6rem;
+        border-radius: 8px;
+        font-size: 0.8rem;
+        font-weight: 600;
+        line-height: 1.3;
+        white-space: nowrap;
+        border: none;
+        background: none;
+    }
+
+    .env-badge:hover { opacity: 0.82; }
+
+    .env-badge.passed {
+        background: #d4edda;
+        color: #155724;
+    }
+
+    .env-badge.failed, .env-badge.error {
+        background: #f8d7da;
+        color: #721c24;
+    }
+
+    .env-badge .ver {
+        font-size: 0.7rem;
+        font-weight: 400;
+        opacity: 0.8;
+        font-family: monospace;
+    }
+
+    /* Failure detail dialog */
+    dialog {
+        border: none;
+        border-radius: 8px;
+        box-shadow: 0 4px 24px rgba(0,0,0,0.22);
+        padding: 0;
+        width: min(640px, 95vw);
+        max-height: 80vh;
+        overflow: hidden;
+    }
+
+    dialog[open] {
+        display: flex;
+        flex-direction: column;
+    }
+
+    dialog::backdrop { background: rgba(0,0,0,0.35); }
+
+    .dlg-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 1rem 1.25rem;
+        border-bottom: 1px solid #e0e0e0;
+        background: #fafafa;
+        flex-shrink: 0;
+    }
+
+    .dlg-title {
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: #1a1a1a;
+    }
+
+    .dlg-close {
+        background: none;
+        border: none;
+        font-size: 1.25rem;
+        cursor: pointer;
+        color: #888;
+        line-height: 1;
+        padding: 0 0.25rem;
+    }
+
+    .dlg-close:hover { color: #333; }
+
+    .dlg-body {
+        overflow-y: auto;
+        padding: 1rem 1.25rem;
+        flex: 1;
+    }
+
+    /* AI analysis block */
+    .ai-block {
+        margin-top: 1rem;
+        border: 1px solid #d0e8ff;
+        border-radius: 6px;
+        overflow: hidden;
+    }
+    .ai-block-header {
+        background: #e8f4ff;
+        color: #0055aa;
+        padding: 0.4rem 0.75rem;
+        font-size: 0.8rem;
+        font-weight: 600;
+    }
+    .ai-root-cause {
+        padding: 0.6rem 0.75rem;
+        font-size: 0.82rem;
+        color: #222;
+        background: #f7fbff;
+        border-bottom: 1px solid #d0e8ff;
+    }
+    .ai-recs {
+        padding: 0.5rem 0.75rem 0.6rem;
+        font-size: 0.8rem;
+        color: #333;
+        background: #f7fbff;
+    }
+    .ai-recs ol { margin: 0.25rem 0 0 1.2rem; padding: 0; }
+    .ai-recs li { margin-bottom: 0.25rem; }
+
+    .dlg-meta {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.2rem 1rem;
+        font-size: 0.875rem;
+        margin-bottom: 1rem;
+        color: #444;
+    }
+
+    .dlg-meta dt { color: #888; font-weight: 500; }
+
+    .fail-list { margin-top: 0.5rem; }
+
+    .fail-item {
+        border: 1px solid #f5c6cb;
+        border-radius: 6px;
+        margin-bottom: 0.75rem;
+        overflow: hidden;
+    }
+
+    .fail-item-name {
+        background: #f8d7da;
+        color: #721c24;
+        padding: 0.4rem 0.75rem;
+        font-size: 0.8rem;
+        font-weight: 600;
+    }
+
+    .fail-item-msg {
+        padding: 0.5rem 0.75rem;
+        font-size: 0.78rem;
+        font-family: monospace;
+        white-space: pre-wrap;
+        word-break: break-word;
+        color: #333;
+        background: #fff9f9;
+        max-height: 200px;
+        overflow-y: auto;
+    }
+
+    .dlg-links {
+        display: flex;
+        gap: 0.75rem;
+        padding: 0.75rem 1.25rem;
+        border-top: 1px solid #e0e0e0;
+        background: #fafafa;
+        flex-shrink: 0;
+    }
+
+    code.version {
+        font-size: 0.8rem;
+        background: #f0f0f0;
+        padding: 0.1rem 0.4rem;
+        border-radius: 3px;
+    }
+</style>
+{{end}}
+
+{{define "content"}}
+<h1 style="margin-bottom: 0.5rem;">Pipelines</h1>
+<p class="text-muted" style="margin-bottom: 1.5rem;">
+    Latest test result per deliverable per environment — sourced from persisted osde2e-logs S3 bucket.
+    Click a status badge to see failure details. Click a deliverable name to see full history.
+</p>
+
+<div class="filter-bar">
+    <label for="op-filter">Filter:</label>
+    <input type="text" id="op-filter" placeholder="e.g. rbac-permissions-operator" autocomplete="off">
+</div>
+
+<div class="card">
+    {{if gt (len .Deliverables) 0}}
+    <table id="op-table">
+        <thead>
+            <tr>
+                <th data-sort="name">Deliverable</th>
+                <th>Integration</th>
+                <th>Stage</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range $i, $op := .Deliverables}}
+            <tr class="op-row" data-name="{{$op.Name}}" onclick="goToDetail('{{$op.Name}}', event)">
+                <td class="name-cell">{{$op.Name}}</td>
+
+                {{/* Integration */}}
+                <td class="status-cell">
+                    {{with $op.Integration}}
+                        <button class="env-badge {{.Status}}" onclick="openDetail('d-{{$i}}-int', event)">
+                            {{if eq .Status "passed"}}✓{{else}}✗{{end}} {{.Version}}
+                        </button>
+                    {{else}}
+                        <span class="badge secondary">—</span>
+                    {{end}}
+                </td>
+
+                {{/* Stage */}}
+                <td class="status-cell">
+                    {{with $op.Stage}}
+                        <button class="env-badge {{.Status}}" onclick="openDetail('d-{{$i}}-stage', event)">
+                            {{if eq .Status "passed"}}✓{{else}}✗{{end}} {{.Version}}
+                        </button>
+                    {{else}}
+                        <span class="badge secondary">—</span>
+                    {{end}}
+                </td>
+            </tr>
+
+            {{end}}{{/* end range .Deliverables */}}
+        </tbody>
+    </table>
+
+    {{/* Dialogs must live outside <tbody> to produce valid HTML */}}
+    {{range $i, $op := .Deliverables}}
+    {{with $op.Stage}}
+    <dialog id="d-{{$i}}-stage">
+        <div class="dlg-header">
+            <span class="dlg-title">{{$op.Name}} — Stage</span>
+            <button class="dlg-close" onclick="this.closest('dialog').close()">✕</button>
+        </div>
+        <div class="dlg-body">
+            <dl class="dlg-meta">
+                <dt>Status</dt>
+                <dd>{{if eq .Status "passed"}}<span class="badge success">Passed</span>{{else}}<span class="badge danger">{{.Status}}</span>{{end}}</dd>
+                <dt>Tag</dt><dd><code class="version">{{.Version}}</code></dd>
+                <dt>Tests</dt><dd>{{.Passed}} passed / {{.Failed}} failed / {{.Total}} total</dd>
+                <dt>Last run</dt><dd>{{.LastRun.Format "2006-01-02 15:04 UTC"}}</dd>
+                <dt>Job suffix</dt><dd><code>{{.JobID}}</code></dd>
+            </dl>
+            {{with .LLMAnalysis}}
+            <div class="ai-block">
+                <div class="ai-block-header">AI Analysis</div>
+                <div class="ai-root-cause">{{.RootCause}}</div>
+                {{if gt (len .Recommendations) 0}}
+                <div class="ai-recs"><strong>Recommendations:</strong>
+                    <ol>{{range .Recommendations}}<li>{{.}}</li>{{end}}</ol>
+                </div>
+                {{end}}
+            </div>
+            {{end}}
+        </div>
+        <div class="dlg-links">
+            {{if .LogURL}}<a href="{{.LogURL}}" target="_blank" rel="noopener noreferrer">Logs</a>{{end}}
+            {{if .JUnitURL}}<a href="{{.JUnitURL}}" target="_blank" rel="noopener noreferrer">JUnit Report</a>{{end}}
+        </div>
+    </dialog>
+    {{end}}
+    {{with $op.Integration}}
+    <dialog id="d-{{$i}}-int">
+        <div class="dlg-header">
+            <span class="dlg-title">{{$op.Name}} — Integration</span>
+            <button class="dlg-close" onclick="this.closest('dialog').close()">✕</button>
+        </div>
+        <div class="dlg-body">
+            <dl class="dlg-meta">
+                <dt>Status</dt>
+                <dd>{{if eq .Status "passed"}}<span class="badge success">Passed</span>{{else}}<span class="badge danger">{{.Status}}</span>{{end}}</dd>
+                <dt>Tag</dt><dd><code class="version">{{.Version}}</code></dd>
+                <dt>Tests</dt><dd>{{.Passed}} passed / {{.Failed}} failed / {{.Total}} total</dd>
+                <dt>Last run</dt><dd>{{.LastRun.Format "2006-01-02 15:04 UTC"}}</dd>
+                <dt>Job suffix</dt><dd><code>{{.JobID}}</code></dd>
+            </dl>
+            {{with .LLMAnalysis}}
+            <div class="ai-block">
+                <div class="ai-block-header">AI Analysis</div>
+                <div class="ai-root-cause">{{.RootCause}}</div>
+                {{if gt (len .Recommendations) 0}}
+                <div class="ai-recs"><strong>Recommendations:</strong>
+                    <ol>{{range .Recommendations}}<li>{{.}}</li>{{end}}</ol>
+                </div>
+                {{end}}
+            </div>
+            {{end}}
+        </div>
+        <div class="dlg-links">
+            {{if .LogURL}}<a href="{{.LogURL}}" target="_blank" rel="noopener noreferrer">Logs</a>{{end}}
+            {{if .JUnitURL}}<a href="{{.JUnitURL}}" target="_blank" rel="noopener noreferrer">JUnit Report</a>{{end}}
+        </div>
+    </dialog>
+    {{end}}
+    {{end}}{{/* end dialog range */}}
+    {{else}}
+    <div class="empty-state">
+        <p>No deliverable results found</p>
+        <p class="text-muted">Results will appear here once tests have run and S3 is configured.</p>
+    </div>
+    {{end}}
+</div>
+{{end}}
+
+{{define "extra-js"}}
+<script>
+(function() {
+    // Filter by operator name
+    var filterInput = document.getElementById('op-filter');
+    if (filterInput) {
+        filterInput.addEventListener('input', function() {
+            var q = this.value.toLowerCase();
+            document.querySelectorAll('#op-table tbody tr.op-row').forEach(function(row) {
+                row.style.display = row.getAttribute('data-name').toLowerCase().includes(q) ? '' : 'none';
+            });
+        });
+    }
+
+    // Column sort (name only now)
+    var sortState = { col: -1, asc: true };
+    document.querySelectorAll('#op-table th[data-sort]').forEach(function(th, idx) {
+        th.addEventListener('click', function() {
+            var tbody = document.querySelector('#op-table tbody');
+            var rows = Array.from(tbody.querySelectorAll('tr.op-row'));
+            var asc = (sortState.col === idx) ? !sortState.asc : true;
+            sortState = { col: idx, asc: asc };
+
+            document.querySelectorAll('#op-table th[data-sort]').forEach(function(h) {
+                h.classList.remove('asc', 'desc');
+            });
+            th.classList.add(asc ? 'asc' : 'desc');
+
+            rows.sort(function(a, b) {
+                var aText = a.cells[idx] ? a.cells[idx].textContent.trim() : '';
+                var bText = b.cells[idx] ? b.cells[idx].textContent.trim() : '';
+                return asc ? aText.localeCompare(bText) : bText.localeCompare(aText);
+            });
+
+            rows.forEach(function(r) { tbody.appendChild(r); });
+        });
+    });
+
+    // Close dialog on backdrop click
+    document.addEventListener('click', function(e) {
+        if (e.target.tagName === 'DIALOG') e.target.close();
+    });
+})();
+
+function openDetail(id, event) {
+    event.stopPropagation(); // don't trigger row click
+    var d = document.getElementById(id);
+    if (d) d.showModal();
+}
+
+function goToDetail(name, event) {
+    // Only navigate if click wasn't on a badge/button
+    if (event.target.closest('button')) return;
+    window.location.href = '/dashboard/pipelines/' + encodeURIComponent(name);
+}
+</script>
+{{end}}

--- a/pkg/dashboard/server/templates/junit-report.html
+++ b/pkg/dashboard/server/templates/junit-report.html
@@ -1,0 +1,229 @@
+{{define "title"}}JUnit Report — Delivery Dashboard{{end}}
+
+{{define "extra-css"}}
+<style>
+.jr-summary {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+.jr-stat {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    padding: 0.75rem 1.25rem;
+    text-align: center;
+    min-width: 90px;
+}
+.jr-stat .jr-count {
+    font-size: 1.75rem;
+    font-weight: 700;
+    line-height: 1.1;
+}
+.jr-stat .jr-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #666;
+    margin-top: 2px;
+}
+.jr-count.passed  { color: #155724; }
+.jr-count.failed  { color: #721c24; }
+.jr-count.skipped { color: #856404; }
+.jr-count.error   { color: #721c24; }
+.jr-count.total   { color: #0066cc; }
+
+.jr-section-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 1.5rem 0 0.5rem;
+    padding-bottom: 0.25rem;
+    border-bottom: 2px solid #e0e0e0;
+}
+.jr-section-title.failures { color: #721c24; border-color: #f5c6cb; }
+.jr-section-title.passed   { color: #155724; border-color: #c3e6cb; }
+.jr-section-title.skipped  { color: #856404; border-color: #ffeeba; }
+
+.jr-suite-name {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #555;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    margin: 0.75rem 0 0.25rem;
+}
+
+details.jr-test {
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    margin-bottom: 0.4rem;
+    background: white;
+}
+details.jr-test[open] {
+    border-color: #aaa;
+}
+details.jr-test summary {
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    list-style: none;
+    user-select: none;
+}
+details.jr-test summary::-webkit-details-marker { display: none; }
+details.jr-test summary::before {
+    content: "▶";
+    font-size: 0.65rem;
+    color: #999;
+    flex-shrink: 0;
+}
+details.jr-test[open] summary::before { content: "▼"; }
+
+.jr-test-name { flex: 1; word-break: break-word; }
+.jr-test-duration { font-size: 0.75rem; color: #888; white-space: nowrap; }
+
+details.jr-test.failed  summary { background: #fff5f5; }
+details.jr-test.error   summary { background: #fff5f5; }
+details.jr-test.skipped summary { background: #fffdf0; }
+details.jr-test.passed  summary { background: #f6fbf6; }
+
+.jr-test-body {
+    padding: 0.75rem;
+    border-top: 1px solid #e0e0e0;
+    font-size: 0.8125rem;
+}
+.jr-test-body pre {
+    background: #f8f8f8;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    padding: 0.5rem 0.75rem;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-size: 0.78rem;
+    line-height: 1.5;
+    color: #333;
+    margin-top: 0.25rem;
+}
+.jr-message-label {
+    font-weight: 600;
+    color: #555;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    margin-bottom: 0.2rem;
+}
+.jr-empty { color: #888; font-style: italic; }
+</style>
+{{end}}
+
+{{define "content"}}
+{{/* Aggregate totals across all suites */}}
+{{$total := 0}}{{$passed := 0}}{{$failed := 0}}{{$skipped := 0}}{{$errors := 0}}
+{{range .Suites}}
+    {{$total   = (add $total   .Totals.Tests)}}
+    {{$passed  = (add $passed  .Totals.Passed)}}
+    {{$failed  = (add $failed  .Totals.Failed)}}
+    {{$skipped = (add $skipped .Totals.Skipped)}}
+    {{$errors  = (add $errors  .Totals.Error)}}
+{{end}}
+
+<div class="jr-summary">
+    <div class="jr-stat"><div class="jr-count total">{{$total}}</div><div class="jr-label">Total</div></div>
+    <div class="jr-stat"><div class="jr-count passed">{{$passed}}</div><div class="jr-label">Passed</div></div>
+    <div class="jr-stat"><div class="jr-count failed">{{add $failed $errors}}</div><div class="jr-label">Failed</div></div>
+    {{if gt $skipped 0}}
+    <div class="jr-stat"><div class="jr-count skipped">{{$skipped}}</div><div class="jr-label">Skipped</div></div>
+    {{end}}
+</div>
+
+{{/* Failures first */}}
+{{$anyFailures := false}}
+{{range .Suites}}{{range .Tests}}{{if or (eq .Status "failed") (eq .Status "error")}}{{$anyFailures = true}}{{end}}{{end}}{{end}}
+
+{{if $anyFailures}}
+<div class="jr-section-title failures">Failures</div>
+{{range .Suites}}
+    {{$suiteName := .Name}}
+    {{range .Tests}}
+    {{if or (eq .Status "failed") (eq .Status "error")}}
+    <details class="jr-test {{.Status}}">
+        <summary>
+            <span class="jr-test-name">{{if .Classname}}{{.Classname}} / {{end}}{{.Name}}</span>
+            <span class="jr-test-duration">{{.Duration}}</span>
+            <span class="badge danger">{{.Status}}</span>
+        </summary>
+        <div class="jr-test-body">
+            {{if .Message}}<div class="jr-message-label">Message</div><pre>{{.Message}}</pre>{{end}}
+            {{if .Error}}<div class="jr-message-label">Detail</div><pre>{{.Error}}</pre>{{end}}
+            {{if .SystemOut}}<div class="jr-message-label">Stdout</div><pre>{{.SystemOut}}</pre>{{end}}
+            {{if .SystemErr}}<div class="jr-message-label">Stderr</div><pre>{{.SystemErr}}</pre>{{end}}
+        </div>
+    </details>
+    {{end}}
+    {{end}}
+{{end}}
+{{end}}
+
+{{/* Passing tests */}}
+{{$anyPassed := false}}
+{{range .Suites}}{{range .Tests}}{{if eq .Status "passed"}}{{$anyPassed = true}}{{end}}{{end}}{{end}}
+
+{{if $anyPassed}}
+<div class="jr-section-title passed">Passed</div>
+{{range .Suites}}
+    {{$suiteName := .Name}}
+    {{$suiteHasPassed := false}}
+    {{range .Tests}}{{if eq .Status "passed"}}{{$suiteHasPassed = true}}{{end}}{{end}}
+    {{if $suiteHasPassed}}
+    <div class="jr-suite-name">{{$suiteName}}</div>
+    {{range .Tests}}
+    {{if eq .Status "passed"}}
+    <details class="jr-test passed">
+        <summary>
+            <span class="jr-test-name">{{if .Classname}}{{.Classname}} / {{end}}{{.Name}}</span>
+            <span class="jr-test-duration">{{.Duration}}</span>
+            <span class="badge success">passed</span>
+        </summary>
+        <div class="jr-test-body">
+            {{if .SystemOut}}<div class="jr-message-label">Stdout</div><pre>{{.SystemOut}}</pre>
+            {{else if .SystemErr}}<div class="jr-message-label">Stderr</div><pre>{{.SystemErr}}</pre>
+            {{else}}<span class="jr-empty">No output captured.</span>{{end}}
+        </div>
+    </details>
+    {{end}}
+    {{end}}
+    {{end}}
+{{end}}
+{{end}}
+
+{{/* Skipped tests */}}
+{{$anySkipped := false}}
+{{range .Suites}}{{range .Tests}}{{if eq .Status "skipped"}}{{$anySkipped = true}}{{end}}{{end}}{{end}}
+
+{{if $anySkipped}}
+<div class="jr-section-title skipped">Skipped</div>
+{{range .Suites}}
+    {{range .Tests}}
+    {{if eq .Status "skipped"}}
+    <details class="jr-test skipped">
+        <summary>
+            <span class="jr-test-name">{{if .Classname}}{{.Classname}} / {{end}}{{.Name}}</span>
+            <span class="jr-test-duration">{{.Duration}}</span>
+            <span class="badge warning">skipped</span>
+        </summary>
+        <div class="jr-test-body">
+            {{if .Message}}<pre>{{.Message}}</pre>{{else}}<span class="jr-empty">No skip reason provided.</span>{{end}}
+        </div>
+    </details>
+    {{end}}
+    {{end}}
+{{end}}
+{{end}}
+
+{{if eq $total 0}}
+<div class="empty-state"><p>No test cases found in this JUnit XML report.</p></div>
+{{end}}
+{{end}}

--- a/pkg/dashboard/server/templates/pipeline-detail.html
+++ b/pkg/dashboard/server/templates/pipeline-detail.html
@@ -1,0 +1,319 @@
+{{template "base.html" .}}
+
+{{define "title"}}Delivery Dashboard - {{.History.Name}}{{end}}
+
+{{define "extra-css"}}
+<style>
+    .back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        color: #0066cc;
+        font-size: 0.875rem;
+        margin-bottom: 1.25rem;
+        text-decoration: none;
+    }
+    .back-link:hover { text-decoration: underline; }
+
+    /* Pipeline grid: version label | int node | arrow | stage node */
+    .pipeline-list { display: flex; flex-direction: column; gap: 0.75rem; }
+
+    .pipeline-row {
+        display: grid;
+        grid-template-columns: 130px 1fr;
+        align-items: center;
+        gap: 0;
+    }
+
+    .pipeline-version {
+        font-size: 0.8rem;
+        font-family: monospace;
+        color: #555;
+        background: #f5f5f5;
+        border: 1px solid #e0e0e0;
+        border-radius: 6px;
+        padding: 0.35rem 0.6rem;
+        text-align: center;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .pipeline-version .ver-date {
+        display: block;
+        font-size: 0.68rem;
+        color: #999;
+        font-family: sans-serif;
+        margin-top: 2px;
+    }
+
+    .pipeline-flow {
+        display: flex;
+        align-items: center;
+        gap: 0;
+    }
+
+    .pipe-connector {
+        width: 24px;
+        height: 2px;
+        background: #ccc;
+        flex-shrink: 0;
+    }
+
+    .pipe-node {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 3px;
+        min-width: 100px;
+    }
+
+    .pipe-node-label {
+        font-size: 0.65rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: #888;
+    }
+
+    .pipe-btn {
+        border: none;
+        border-radius: 8px;
+        padding: 0.35rem 0.9rem;
+        font-size: 0.8rem;
+        font-weight: 600;
+        cursor: pointer;
+        white-space: nowrap;
+        min-width: 80px;
+        text-align: center;
+    }
+
+    .pipe-btn.passed  { background: #d4edda; color: #155724; cursor: default; }
+    .pipe-btn.failed,
+    .pipe-btn.error   { background: #f8d7da; color: #721c24; cursor: pointer; }
+    .pipe-btn.failed:hover,
+    .pipe-btn.error:hover { opacity: 0.85; }
+    .pipe-btn.skipped { background: #e2e3e5; color: #555; cursor: default; }
+
+    .pipe-arrow {
+        display: flex;
+        align-items: center;
+        padding: 0 4px;
+        color: #bbb;
+        font-size: 1.1rem;
+        flex-shrink: 0;
+    }
+
+    /* Dialog */
+    dialog {
+        border: none;
+        border-radius: 8px;
+        box-shadow: 0 4px 24px rgba(0,0,0,0.22);
+        padding: 0;
+        width: min(640px, 95vw);
+        max-height: 80vh;
+        overflow: hidden;
+    }
+    dialog[open] { display: flex; flex-direction: column; }
+    dialog::backdrop { background: rgba(0,0,0,0.35); }
+
+    .dlg-header {
+        display: flex; align-items: center; justify-content: space-between;
+        padding: 1rem 1.25rem; border-bottom: 1px solid #e0e0e0;
+        background: #fafafa; flex-shrink: 0;
+    }
+    .dlg-title { font-size: 0.95rem; font-weight: 600; color: #1a1a1a; }
+    .dlg-close {
+        background: none; border: none; font-size: 1.25rem;
+        cursor: pointer; color: #888; line-height: 1; padding: 0 0.25rem;
+    }
+    .dlg-close:hover { color: #333; }
+    .dlg-body { overflow-y: auto; padding: 1rem 1.25rem; flex: 1; }
+    .dlg-meta {
+        display: grid; grid-template-columns: auto 1fr;
+        gap: 0.2rem 1rem; font-size: 0.875rem; margin-bottom: 1rem; color: #444;
+    }
+    .dlg-meta dt { color: #888; font-weight: 500; }
+
+    .fail-list { margin-top: 0.5rem; }
+    .fail-item { border: 1px solid #f5c6cb; border-radius: 6px; margin-bottom: 0.75rem; overflow: hidden; }
+    .fail-item-name { background: #f8d7da; color: #721c24; padding: 0.4rem 0.75rem; font-size: 0.8rem; font-weight: 600; }
+    .fail-item-msg {
+        padding: 0.5rem 0.75rem; font-size: 0.78rem; font-family: monospace;
+        white-space: pre-wrap; word-break: break-word; color: #333;
+        background: #fff9f9; max-height: 200px; overflow-y: auto;
+    }
+    .dlg-links {
+        display: flex; gap: 0.75rem; padding: 0.75rem 1.25rem;
+        border-top: 1px solid #e0e0e0; background: #fafafa; flex-shrink: 0;
+    }
+
+    .ai-block { margin-top: 1rem; border: 1px solid #d0e8ff; border-radius: 6px; overflow: hidden; }
+    .ai-block-header { background: #e8f4ff; color: #0055aa; padding: 0.4rem 0.75rem; font-size: 0.8rem; font-weight: 600; }
+    .ai-root-cause { padding: 0.6rem 0.75rem; font-size: 0.82rem; color: #222; background: #f7fbff; border-bottom: 1px solid #d0e8ff; }
+    .ai-recs { padding: 0.5rem 0.75rem 0.6rem; font-size: 0.8rem; color: #333; background: #f7fbff; }
+    .ai-recs ol { margin: 0.25rem 0 0 1.2rem; padding: 0; }
+    .ai-recs li { margin-bottom: 0.25rem; }
+
+    code.version { font-size: 0.8rem; background: #f0f0f0; padding: 0.1rem 0.4rem; border-radius: 3px; }
+</style>
+{{end}}
+
+{{define "content"}}
+<a class="back-link" href="/dashboard/pipelines">← Back to Pipelines</a>
+
+<h1 style="margin-bottom: 0.25rem;">{{.History.Name}}</h1>
+<p class="text-muted" style="margin-bottom: 1.5rem;">
+    Each row is a version of this deliverable. Runs flow <strong>int → stage</strong>. Click a failed node to see details.
+</p>
+
+<div class="card">
+{{if gt (len .History.Versions) 0}}
+
+    {{/* Column headers */}}
+    <div style="display:grid; grid-template-columns: 130px 1fr; margin-bottom: 0.75rem; padding-bottom: 0.5rem; border-bottom: 1px solid #e0e0e0;">
+        <div style="font-size:0.72rem; font-weight:700; text-transform:uppercase; letter-spacing:0.5px; color:#888;">Version</div>
+        <div style="display:flex; gap:0; align-items:center;">
+            <div style="min-width:24px;"></div>
+            <div style="min-width:100px; font-size:0.72rem; font-weight:700; text-transform:uppercase; letter-spacing:0.5px; color:#888; text-align:center;">Int</div>
+            <div style="width:32px;"></div>
+            <div style="min-width:100px; font-size:0.72rem; font-weight:700; text-transform:uppercase; letter-spacing:0.5px; color:#888; text-align:center;">Stage</div>
+        </div>
+    </div>
+
+    <div class="pipeline-list">
+    {{range $vi, $vp := .History.Versions}}
+
+    {{$intRun   := index $vp.EnvRuns "int"}}
+    {{$stageRun := index $vp.EnvRuns "stage"}}
+
+    <div class="pipeline-row">
+        {{/* Version label */}}
+        <div class="pipeline-version">
+            <a href="https://github.com/openshift/{{$.History.Name | githubRepo}}/commit/{{$vp.Version}}" target="_blank" rel="noopener noreferrer" style="font-family:monospace;">{{$vp.Version}}</a>
+            <span class="ver-date">{{$vp.LastRun.Format "2006-01-02"}}</span>
+        </div>
+
+        {{/* Pipeline flow: connector → int node → arrow → stage node */}}
+        <div class="pipeline-flow">
+            <div class="pipe-connector"></div>
+
+            {{/* Int node */}}
+            <div class="pipe-node">
+                {{if $intRun}}
+                    {{if eq $intRun.Status "passed"}}
+                        <button class="pipe-btn passed">✓ passed</button>
+                    {{else}}
+                        <button class="pipe-btn {{$intRun.Status}}" onclick="openDetail('d-{{$vi}}-int')">✗ {{$intRun.Status}}</button>
+                    {{end}}
+                {{else}}
+                    <span class="pipe-btn skipped">—</span>
+                {{end}}
+            </div>
+
+            {{/* Arrow */}}
+            <div class="pipe-arrow">→</div>
+
+            {{/* Stage node */}}
+            <div class="pipe-node">
+                {{if $stageRun}}
+                    {{if eq $stageRun.Status "passed"}}
+                        <button class="pipe-btn passed">✓ passed</button>
+                    {{else}}
+                        <button class="pipe-btn {{$stageRun.Status}}" onclick="openDetail('d-{{$vi}}-stage')">✗ {{$stageRun.Status}}</button>
+                    {{end}}
+                {{else}}
+                    <span class="pipe-btn skipped">—</span>
+                {{end}}
+            </div>
+        </div>
+    </div>
+
+    {{/* Dialogs for failed runs */}}
+    {{if $intRun}}{{if ne $intRun.Status "passed"}}
+    <dialog id="d-{{$vi}}-int">
+        <div class="dlg-header">
+            <span class="dlg-title"><code class="version">{{$vp.Version}}</code> — Int — {{$intRun.Date}}</span>
+            <button class="dlg-close" onclick="this.closest('dialog').close()">✕</button>
+        </div>
+        <div class="dlg-body">
+            <dl class="dlg-meta">
+                <dt>Status</dt><dd><span class="badge danger">{{$intRun.Status}}</span></dd>
+                <dt>Tests</dt><dd>{{$intRun.Passed}} passed / {{subtract $intRun.Total $intRun.Passed}} failed / {{$intRun.Total}} total</dd>
+                <dt>Run at</dt><dd>{{$intRun.LastRun.Format "2006-01-02 15:04 UTC"}}</dd>
+                <dt>Job suffix</dt><dd><code>{{$intRun.JobID}}</code></dd>
+            </dl>
+            {{with $intRun.LLMAnalysis}}
+            <div class="ai-block">
+                <div class="ai-block-header">AI Analysis</div>
+                <div class="ai-root-cause">{{.RootCause}}</div>
+                {{if gt (len .Recommendations) 0}}
+                <div class="ai-recs"><strong>Recommendations:</strong>
+                    <ol>{{range .Recommendations}}<li>{{.}}</li>{{end}}</ol>
+                </div>
+                {{end}}
+            </div>
+            {{end}}
+        </div>
+        <div class="dlg-links">
+            {{if $intRun.LogURL}}<a href="{{$intRun.LogURL}}" target="_blank" rel="noopener noreferrer">Logs</a>{{end}}
+            {{if $intRun.JUnitURL}}<a href="{{$intRun.JUnitURL}}" target="_blank" rel="noopener noreferrer">JUnit Report</a>{{end}}
+        </div>
+    </dialog>
+    {{end}}{{end}}
+
+    {{if $stageRun}}{{if ne $stageRun.Status "passed"}}
+    <dialog id="d-{{$vi}}-stage">
+        <div class="dlg-header">
+            <span class="dlg-title"><code class="version">{{$vp.Version}}</code> — Stage — {{$stageRun.Date}}</span>
+            <button class="dlg-close" onclick="this.closest('dialog').close()">✕</button>
+        </div>
+        <div class="dlg-body">
+            <dl class="dlg-meta">
+                <dt>Status</dt><dd><span class="badge danger">{{$stageRun.Status}}</span></dd>
+                <dt>Tests</dt><dd>{{$stageRun.Passed}} passed / {{subtract $stageRun.Total $stageRun.Passed}} failed / {{$stageRun.Total}} total</dd>
+                <dt>Run at</dt><dd>{{$stageRun.LastRun.Format "2006-01-02 15:04 UTC"}}</dd>
+                <dt>Job suffix</dt><dd><code>{{$stageRun.JobID}}</code></dd>
+            </dl>
+            {{with $stageRun.LLMAnalysis}}
+            <div class="ai-block">
+                <div class="ai-block-header">AI Analysis</div>
+                <div class="ai-root-cause">{{.RootCause}}</div>
+                {{if gt (len .Recommendations) 0}}
+                <div class="ai-recs"><strong>Recommendations:</strong>
+                    <ol>{{range .Recommendations}}<li>{{.}}</li>{{end}}</ol>
+                </div>
+                {{end}}
+            </div>
+            {{end}}
+        </div>
+        <div class="dlg-links">
+            {{if $stageRun.LogURL}}<a href="{{$stageRun.LogURL}}" target="_blank" rel="noopener noreferrer">Logs</a>{{end}}
+            {{if $stageRun.JUnitURL}}<a href="{{$stageRun.JUnitURL}}" target="_blank" rel="noopener noreferrer">JUnit Report</a>{{end}}
+        </div>
+    </dialog>
+    {{end}}{{end}}
+
+    {{end}}{{/* end range Versions */}}
+    </div>
+
+{{else}}
+<div class="empty-state">
+    <p>No historical runs found for <strong>{{.History.Name}}</strong></p>
+    <p class="text-muted">Runs will appear here once test results are uploaded to S3.</p>
+</div>
+{{end}}
+</div>
+{{end}}
+
+{{define "extra-js"}}
+<script>
+function openDetail(id) {
+    var d = document.getElementById(id);
+    if (d) d.showModal();
+}
+document.addEventListener('click', function(e) {
+    if (e.target.tagName === 'DIALOG') e.target.close();
+});
+</script>
+{{end}}

--- a/pkg/dashboard/server/templates/usage.html
+++ b/pkg/dashboard/server/templates/usage.html
@@ -1,0 +1,218 @@
+{{template "base.html" .}}
+
+{{define "title"}}Delivery Dashboard - Infra{{end}}
+
+{{define "extra-css"}}
+<style>
+    .env-section {
+        margin-bottom: 2rem;
+    }
+
+    .env-section h2 {
+        font-size: 1.1rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: #555;
+        margin-bottom: 0.75rem;
+        padding-bottom: 0.4rem;
+        border-bottom: 2px solid #e0e0e0;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        user-select: none;
+    }
+
+    .env-section h2:hover { color: #222; }
+
+    .env-section h2 .toggle-icon {
+        font-size: 0.75rem;
+        color: #999;
+        transition: transform 0.2s;
+    }
+
+    .env-section h2 .count {
+        font-size: 0.8rem;
+        font-weight: 400;
+        color: #888;
+        margin-left: auto;
+    }
+
+    .env-table-wrap { overflow-x: auto; }
+
+    table.cluster-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.85rem;
+    }
+
+    .cluster-table th {
+        background: #f8f8f8;
+        font-weight: 600;
+        color: #444;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        padding: 0.6rem 0.75rem;
+        border-bottom: 1px solid #e0e0e0;
+        text-align: left;
+        white-space: nowrap;
+    }
+
+    .cluster-table td {
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid #f0f0f0;
+        vertical-align: middle;
+    }
+
+    .cluster-table tr:last-child td { border-bottom: none; }
+    .cluster-table tr:hover td { background: #f9f9f9; }
+
+    code.clid {
+        font-size: 0.78rem;
+        background: #f0f0f0;
+        padding: 0.1rem 0.35rem;
+        border-radius: 3px;
+        font-family: monospace;
+    }
+
+    .avail-badge {
+        display: inline-block;
+        padding: 0.15rem 0.5rem;
+        border-radius: 10px;
+        font-size: 0.72rem;
+        font-weight: 600;
+        text-transform: uppercase;
+    }
+
+    .avail-reserved  { background: #d1ecf1; color: #0c5460; }
+    .avail-claimed   { background: #fff3cd; color: #856404; }
+    .avail-used      { background: #d4edda; color: #155724; }
+    .avail-other     { background: #e2e3e5; color: #383d41; }
+
+    .state-ready     { color: #155724; font-weight: 600; }
+    .state-installing{ color: #0c5460; }
+    .state-error     { color: #721c24; font-weight: 600; }
+
+    .datetime { white-space: nowrap; font-size: 0.8rem; color: #555; }
+    .expiring  { color: #c0392b; font-weight: 600; }
+
+    .image-tag {
+        font-size: 0.78rem;
+        font-family: monospace;
+        color: #444;
+        max-width: 220px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        display: block;
+    }
+</style>
+{{end}}
+
+{{define "content"}}
+<h1 style="margin-bottom: 0.5rem;">Infra</h1>
+<p class="text-muted" style="margin-bottom: 1.5rem;">All osde2e clusters across environments. Click an environment heading to collapse.</p>
+
+{{if gt (len .EnvClusters) 0}}
+    {{range .EnvClusters}}
+    <div class="card env-section">
+        <h2 onclick="toggleSection(this)">
+            <span class="toggle-icon">▼</span>
+            {{.Env}}
+            <span class="count">{{len .Clusters}} clusters</span>
+        </h2>
+        <div class="env-table-wrap">
+        {{if gt (len .Clusters) 0}}
+        <table class="cluster-table">
+            <thead>
+                <tr>
+                    <th>Cluster ID</th>
+                    <th>State</th>
+                    <th>Availability</th>
+                    <th>Version</th>
+                    <th>Flavor</th>
+                    <th>Ad Hoc Image</th>
+                    <th>Created</th>
+                    <th>Expires</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .Clusters}}
+                <tr>
+                    <td><code class="clid">{{.ID}}</code></td>
+                    <td>
+                        {{if eq .State "ready"}}
+                            <span class="state-ready">● ready</span>
+                        {{else if eq .State "installing"}}
+                            <span class="state-installing">◌ installing</span>
+                        {{else if eq .State "error"}}
+                            <span class="state-error">✗ error</span>
+                        {{else}}
+                            <span class="text-muted">{{.State}}</span>
+                        {{end}}
+                    </td>
+                    <td>
+                        {{$avail := index .Properties "Availability"}}
+                        {{if eq $avail "reserved"}}
+                            <span class="avail-badge avail-reserved">reserved</span>
+                        {{else if eq $avail "claimed"}}
+                            <span class="avail-badge avail-claimed">claimed</span>
+                        {{else if eq $avail "used"}}
+                            <span class="avail-badge avail-used">used</span>
+                        {{else if $avail}}
+                            <span class="avail-badge avail-other">{{$avail}}</span>
+                        {{else}}
+                            <span class="text-muted">—</span>
+                        {{end}}
+                    </td>
+                    <td>{{.Version}}</td>
+                    <td>{{.Product}}</td>
+                    <td>
+                        {{$img := index .Properties "AdHocTestImages"}}
+                        {{if $img}}
+                            <span class="image-tag" title="{{$img}}">{{$img}}</span>
+                        {{else}}
+                            <span class="text-muted">—</span>
+                        {{end}}
+                    </td>
+                    <td class="datetime">{{localTime .CreatedAt}}</td>
+                    <td class="datetime {{if .ExpiringSoon}}expiring{{end}}">
+                        {{if .ExpiresAt.IsZero}}—{{else}}{{localTime .ExpiresAt}}{{end}}
+                    </td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+        {{else}}
+        <p class="text-muted" style="padding: 1rem 0;">No clusters found for this environment.</p>
+        {{end}}
+        </div>
+    </div>
+    {{end}}
+{{else}}
+<div class="card">
+    <div class="empty-state">
+        <p>No cluster data available</p>
+        <p class="text-muted">OCM credentials may not be configured, or no osde2e clusters exist.</p>
+    </div>
+</div>
+{{end}}
+{{end}}
+
+{{define "extra-js"}}
+<script>
+function toggleSection(h2) {
+    var wrap = h2.nextElementSibling;
+    var icon = h2.querySelector('.toggle-icon');
+    if (wrap.style.display === 'none') {
+        wrap.style.display = '';
+        icon.style.transform = '';
+    } else {
+        wrap.style.display = 'none';
+        icon.style.transform = 'rotate(-90deg)';
+    }
+}
+</script>
+{{end}}

--- a/pkg/dashboard/store/store.go
+++ b/pkg/dashboard/store/store.go
@@ -1,0 +1,513 @@
+// Package store provides a SQLite-backed persistence layer for pipeline results.
+// It is written to by the SQS consumer (incremental) and the backfill job (bulk),
+// and read by the dashboard HTTP handlers for sub-millisecond page loads.
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite" // pure-Go SQLite driver, no CGO required
+
+	"github.com/openshift/osde2e/pkg/dashboard/models"
+)
+
+const schema = `
+PRAGMA journal_mode=WAL;
+PRAGMA foreign_keys=ON;
+
+-- Latest result per (operator, env) — used by the Pipelines overview table.
+CREATE TABLE IF NOT EXISTS pipeline_latest (
+    name TEXT NOT NULL,
+    env           TEXT NOT NULL,
+    version       TEXT NOT NULL DEFAULT 'unknown',
+    status        TEXT NOT NULL DEFAULT 'unknown',
+    passed        INTEGER NOT NULL DEFAULT 0,
+    failed        INTEGER NOT NULL DEFAULT 0,
+    total         INTEGER NOT NULL DEFAULT 0,
+    job_id        TEXT NOT NULL DEFAULT '',
+    last_run      DATETIME NOT NULL,
+    log_url       TEXT NOT NULL DEFAULT '',
+    junit_url     TEXT NOT NULL DEFAULT '',
+    failed_tests  TEXT NOT NULL DEFAULT '[]', -- JSON []FailedTestCase
+    llm_analysis  TEXT NOT NULL DEFAULT '',   -- JSON LLMAnalysis or empty
+    PRIMARY KEY (name, env)
+);
+
+-- Every individual run — used by the pipeline-detail history page.
+CREATE TABLE IF NOT EXISTS pipeline_runs (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    env           TEXT NOT NULL,
+    version       TEXT NOT NULL DEFAULT 'unknown',
+    status        TEXT NOT NULL DEFAULT 'unknown',
+    passed        INTEGER NOT NULL DEFAULT 0,
+    failed        INTEGER NOT NULL DEFAULT 0,
+    total         INTEGER NOT NULL DEFAULT 0,
+    job_id        TEXT NOT NULL DEFAULT '',
+    date          TEXT NOT NULL DEFAULT '',
+    last_run      DATETIME NOT NULL,
+    log_url       TEXT NOT NULL DEFAULT '',
+    junit_url     TEXT NOT NULL DEFAULT '',
+    failed_tests  TEXT NOT NULL DEFAULT '[]', -- JSON []FailedTestCase
+    llm_analysis  TEXT NOT NULL DEFAULT '',   -- JSON LLMAnalysis or empty
+    UNIQUE (name, env, job_id)       -- deduplicate on re-process
+);
+
+CREATE INDEX IF NOT EXISTS idx_runs_operator ON pipeline_runs (name, last_run DESC);
+
+-- Migration: add llm_analysis column to existing DBs that predate this field.
+-- SQLite ignores "duplicate column" errors but this pattern avoids them.
+`
+
+// Store wraps the SQLite database connection and provides typed query methods.
+type Store struct {
+	db *sql.DB
+}
+
+// Open opens (or creates) the SQLite database at path and applies the schema.
+// Use ":memory:" for an in-memory database (useful for tests).
+func Open(path string) (*Store, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite %s: %w", path, err)
+	}
+
+	// SQLite performs best with a single writer connection.
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec(schema); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("apply schema: %w", err)
+	}
+
+	// Best-effort migrations for existing databases.
+	for _, tbl := range []string{"pipeline_latest", "pipeline_runs"} {
+		_, _ = db.Exec(`ALTER TABLE ` + tbl + ` ADD COLUMN llm_analysis TEXT NOT NULL DEFAULT ''`)
+		_, _ = db.Exec(`ALTER TABLE ` + tbl + ` RENAME COLUMN operator_name TO name`)
+		// Rewrite old presigned/plain S3 URLs to dashboard proxy URLs.
+		// Extract the S3 key by stripping the bucket hostname prefix, then build /dashboard/s3?key= or /dashboard/junit?key= URLs.
+		// Handles both https://bucket.s3.amazonaws.com/key?presign and previously-migrated https://bucket.s3.amazonaws.com/key forms.
+		_, _ = db.Exec(`UPDATE ` + tbl + ` SET log_url = '/dashboard/s3?key=' || SUBSTR(SUBSTR(log_url, 1, INSTR(log_url||'?', '?')-1), INSTR(SUBSTR(log_url, 1, INSTR(log_url||'?', '?')-1), '.amazonaws.com/') + LENGTH('.amazonaws.com/')) WHERE log_url LIKE 'https://%'`)
+		_, _ = db.Exec(`UPDATE ` + tbl + ` SET junit_url = '/dashboard/junit?key=' || SUBSTR(SUBSTR(junit_url, 1, INSTR(junit_url||'?', '?')-1), INSTR(SUBSTR(junit_url, 1, INSTR(junit_url||'?', '?')-1), '.amazonaws.com/') + LENGTH('.amazonaws.com/')) WHERE junit_url LIKE 'https://%'`)
+	}
+
+	log.Printf("Store: opened SQLite at %s", path)
+	return &Store{db: db}, nil
+}
+
+// Close closes the underlying database connection.
+func (s *Store) Close() error { return s.db.Close() }
+
+// Truncate removes all rows from pipeline_latest and pipeline_runs.
+// Called before a full backfill so stale rows (S3 objects that have been deleted) don't persist.
+func (s *Store) Truncate() error {
+	for _, tbl := range []string{"pipeline_latest", "pipeline_runs"} {
+		if _, err := s.db.Exec(`DELETE FROM ` + tbl); err != nil {
+			return fmt.Errorf("truncate %s: %w", tbl, err)
+		}
+	}
+	return nil
+}
+
+// RunRecord is the flat struct used when writing to the store.
+type RunRecord struct {
+	Name string
+	Env          string
+	Version      string
+	Status       string
+	Passed       int
+	Failed       int
+	Total        int
+	JobID        string
+	Date         string
+	LastRun      time.Time
+	LogURL       string
+	JUnitURL     string
+	FailedTests  []models.FailedTestCase
+	LLMAnalysis  *models.LLMAnalysis
+}
+
+// UpsertRun inserts or updates both pipeline_latest and pipeline_runs for one run result.
+func (s *Store) UpsertRun(r RunRecord) error {
+	ft, err := json.Marshal(r.FailedTests)
+	if err != nil {
+		return fmt.Errorf("marshal failed_tests: %w", err)
+	}
+
+	llmStr := ""
+	if r.LLMAnalysis != nil {
+		b, err := json.Marshal(r.LLMAnalysis)
+		if err != nil {
+			return fmt.Errorf("marshal llm_analysis: %w", err)
+		}
+		llmStr = string(b)
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Upsert pipeline_latest — only overwrite if this run is newer.
+	_, err = tx.Exec(`
+		INSERT INTO pipeline_latest
+			(name, env, version, status, passed, failed, total, job_id, last_run, log_url, junit_url, failed_tests, llm_analysis)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(name, env) DO UPDATE SET
+			version      = excluded.version,
+			status       = excluded.status,
+			passed       = excluded.passed,
+			failed       = excluded.failed,
+			total        = excluded.total,
+			job_id       = excluded.job_id,
+			last_run     = excluded.last_run,
+			log_url      = excluded.log_url,
+			junit_url    = excluded.junit_url,
+			failed_tests = excluded.failed_tests,
+			llm_analysis = excluded.llm_analysis
+		WHERE excluded.last_run > pipeline_latest.last_run
+	`,
+		r.Name, r.Env, r.Version, r.Status,
+		r.Passed, r.Failed, r.Total,
+		r.JobID, r.LastRun, r.LogURL, r.JUnitURL,
+		string(ft), llmStr,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert pipeline_latest: %w", err)
+	}
+
+	// Insert pipeline_runs — ignore duplicate job_id.
+	_, err = tx.Exec(`
+		INSERT OR IGNORE INTO pipeline_runs
+			(name, env, version, status, passed, failed, total, job_id, date, last_run, log_url, junit_url, failed_tests, llm_analysis)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		r.Name, r.Env, r.Version, r.Status,
+		r.Passed, r.Failed, r.Total,
+		r.JobID, r.Date, r.LastRun, r.LogURL, r.JUnitURL,
+		string(ft), llmStr,
+	)
+	if err != nil {
+		return fmt.Errorf("insert pipeline_runs: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// GetLatest returns all rows from pipeline_latest as []models.DeliverableStatus,
+// grouped by operator name (one entry per operator, results keyed by env).
+func (s *Store) GetLatest() ([]models.DeliverableStatus, error) {
+	rows, err := s.db.Query(`
+		SELECT name, env, version, status, passed, failed, total,
+		       job_id, last_run, log_url, junit_url, failed_tests, llm_analysis
+		FROM pipeline_latest
+		ORDER BY name, env
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query pipeline_latest: %w", err)
+	}
+	defer rows.Close()
+
+	index := make(map[string]*models.DeliverableStatus)
+	var order []string
+
+	for rows.Next() {
+		var (
+			name, env, ver, status  string
+			passed, failed, total   int
+			jobID, logURL, junitURL string
+			lastRun                 time.Time
+			ftJSON, llmJSON         string
+		)
+		if err := rows.Scan(&name, &env, &ver, &status, &passed, &failed, &total,
+			&jobID, &lastRun, &logURL, &junitURL, &ftJSON, &llmJSON); err != nil {
+			return nil, fmt.Errorf("scan pipeline_latest: %w", err)
+		}
+
+		var failedTests []models.FailedTestCase
+		_ = json.Unmarshal([]byte(ftJSON), &failedTests)
+
+		var llm *models.LLMAnalysis
+		if llmJSON != "" {
+			llm = &models.LLMAnalysis{}
+			if err := json.Unmarshal([]byte(llmJSON), llm); err != nil {
+				llm = nil
+			}
+		}
+
+		er := &models.EnvironmentResult{
+			Version:     ver,
+			Status:      status,
+			Passed:      passed,
+			Failed:      failed,
+			Total:       total,
+			JobID:       jobID,
+			LastRun:     lastRun,
+			LogURL:      logURL,
+			JUnitURL:    junitURL,
+			FailedTests: failedTests,
+			LLMAnalysis: llm,
+		}
+
+		op, ok := index[name]
+		if !ok {
+			op = &models.DeliverableStatus{
+				Name:    name,
+				Results: make(map[string]*models.EnvironmentResult),
+			}
+			index[name] = op
+			order = append(order, name)
+		}
+		op.Results[env] = er
+		if lastRun.After(op.LastUpdated) {
+			op.LastUpdated = lastRun
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	result := make([]models.DeliverableStatus, 0, len(order))
+	for _, name := range order {
+		result = append(result, *index[name])
+	}
+	return result, nil
+}
+
+// GetHistory returns all pipeline_runs for a given operator, newest first.
+func (s *Store) GetHistory(operatorName string) (*models.PipelineHistory, error) {
+	rows, err := s.db.Query(`
+		SELECT env, version, status, passed, failed, total,
+		       job_id, date, last_run, log_url, junit_url, failed_tests, llm_analysis
+		FROM pipeline_runs
+		WHERE name = ?
+		ORDER BY last_run DESC
+	`, operatorName)
+	if err != nil {
+		return nil, fmt.Errorf("query pipeline_runs: %w", err)
+	}
+	defer rows.Close()
+
+	var runs []models.PipelineRun
+	for rows.Next() {
+		var (
+			env, ver, status        string
+			passed, failed, total   int
+			jobID, date             string
+			logURL, junitURL        string
+			lastRun                 time.Time
+			ftJSON, llmJSON         string
+		)
+		if err := rows.Scan(&env, &ver, &status, &passed, &failed, &total,
+			&jobID, &date, &lastRun, &logURL, &junitURL, &ftJSON, &llmJSON); err != nil {
+			return nil, fmt.Errorf("scan pipeline_runs: %w", err)
+		}
+
+		var failedTests []models.FailedTestCase
+		_ = json.Unmarshal([]byte(ftJSON), &failedTests)
+
+		var llm *models.LLMAnalysis
+		if llmJSON != "" {
+			llm = &models.LLMAnalysis{}
+			if err := json.Unmarshal([]byte(llmJSON), llm); err != nil {
+				llm = nil
+			}
+		}
+
+		runs = append(runs, models.PipelineRun{
+			Env:         env,
+			Version:     ver,
+			Status:      status,
+			Passed:      passed,
+			Total:       total,
+			JobID:       jobID,
+			Date:        date,
+			LastRun:     lastRun,
+			LogURL:      logURL,
+			JUnitURL:    junitURL,
+			Failed:      failedTests,
+			LLMAnalysis: llm,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Group runs by version, preserving newest-first order per version.
+	// For each version we keep the newest run per env (int takes precedence over stage over prod).
+	type versionKey = string
+	versionOrder := []versionKey{}
+	versionMap := make(map[versionKey]*models.VersionPipeline)
+
+	for i := range runs {
+		run := &runs[i]
+		vp, exists := versionMap[run.Version]
+		if !exists {
+			vp = &models.VersionPipeline{
+				Version: run.Version,
+				Date:    run.Date,
+				LastRun: run.LastRun,
+				EnvRuns: make(map[string]*models.PipelineRun),
+			}
+			versionMap[run.Version] = vp
+			versionOrder = append(versionOrder, run.Version)
+		}
+		// Keep newest run per env (runs are already newest-first so first wins).
+		if _, seen := vp.EnvRuns[run.Env]; !seen {
+			vp.EnvRuns[run.Env] = run
+		}
+		if run.LastRun.After(vp.LastRun) {
+			vp.LastRun = run.LastRun
+			vp.Date = run.Date
+		}
+	}
+
+	versions := make([]models.VersionPipeline, 0, len(versionOrder))
+	for _, ver := range versionOrder {
+		versions = append(versions, *versionMap[ver])
+	}
+
+	return &models.PipelineHistory{
+		Name: operatorName,
+		Runs:         runs,
+		Versions:     versions,
+	}, nil
+}
+
+// groupKeySummary extracts a stable grouping key from an LLM root cause or failure message.
+// It takes the first sentence (up to the first '.') capped at 120 chars, then normalises
+// to lowercase with punctuation/quotes stripped so minor LLM phrasing differences still cluster.
+func groupKeySummary(text string) string {
+	if text == "" {
+		return ""
+	}
+	s := text
+	// Trim to first sentence
+	if idx := strings.Index(s, "."); idx > 0 && idx < 120 {
+		s = s[:idx]
+	} else if len(s) > 120 {
+		s = s[:120]
+	}
+	// Normalise: lowercase, strip quotes and leading/trailing punctuation
+	s = strings.ToLower(s)
+	s = strings.Map(func(r rune) rune {
+		switch r {
+		case '\'', '"', '`', '‘', '’', '“', '”':
+			return -1 // drop quote characters
+		}
+		return r
+	}, s)
+	return strings.TrimSpace(s)
+}
+
+// GetFailureGroups returns all failed runs grouped by the first sentence of the LLM root cause
+// (falling back to the first line of the failure message). Groups with the same summary cluster
+// across deliverables. Sorted by number of entries descending.
+func (s *Store) GetFailureGroups() ([]models.FailureGroup, error) {
+	rows, err := s.db.Query(`
+		SELECT name, env, version, job_id, last_run, log_url, failed_tests, llm_analysis
+		FROM pipeline_runs
+		WHERE status != 'passed' AND (failed_tests != '[]' OR llm_analysis != '')
+		ORDER BY last_run DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query failure groups: %w", err)
+	}
+	defer rows.Close()
+
+	type groupKey = string
+	groupOrder := []groupKey{}
+	groups := make(map[groupKey]*models.FailureGroup)
+
+	for rows.Next() {
+		var (
+			name, env, ver, jobID   string
+			logURL, ftJSON, llmJSON string
+			lastRun                 time.Time
+		)
+		if err := rows.Scan(&name, &env, &ver, &jobID, &lastRun, &logURL, &ftJSON, &llmJSON); err != nil {
+			return nil, fmt.Errorf("scan failure groups: %w", err)
+		}
+
+		var llm *models.LLMAnalysis
+		if llmJSON != "" {
+			llm = &models.LLMAnalysis{}
+			if err := json.Unmarshal([]byte(llmJSON), llm); err != nil || llm.RootCause == "" {
+				llm = nil
+			}
+		}
+
+		var failedTests []models.FailedTestCase
+		_ = json.Unmarshal([]byte(ftJSON), &failedTests)
+
+		// Determine grouping key: prefer LLM root cause summary, fall back to first failure message line
+		var key string
+		if llm != nil {
+			key = groupKeySummary(llm.RootCause)
+		}
+		if key == "" && len(failedTests) > 0 {
+			// First line of the first failure message
+			msg := failedTests[0].Message
+			if nl := strings.Index(msg, "\n"); nl > 0 {
+				msg = msg[:nl]
+			}
+			key = groupKeySummary(msg)
+		}
+		if key == "" {
+			continue
+		}
+
+		entry := models.FailureEntry{
+			Name: name,
+			Version:      ver,
+			Env:          env,
+			LastRun:      lastRun,
+			JobID:        jobID,
+			LogURL:       logURL,
+		}
+
+		if _, exists := groups[key]; !exists {
+			grp := &models.FailureGroup{
+				FailureMatch: key,
+			}
+			if llm != nil {
+				grp.RootCause = llm.RootCause
+				grp.Recommendations = llm.Recommendations
+			}
+			groups[key] = grp
+			groupOrder = append(groupOrder, key)
+		}
+		grp := groups[key]
+		grp.Entries = append(grp.Entries, entry)
+		// Enrich with LLM if the group doesn't have it yet
+		if llm != nil && grp.RootCause == "" {
+			grp.RootCause = llm.RootCause
+			grp.Recommendations = llm.Recommendations
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	result := make([]models.FailureGroup, 0, len(groupOrder))
+	for _, key := range groupOrder {
+		result = append(result, *groups[key])
+	}
+	// Sort: largest groups first
+	for i := 0; i < len(result)-1; i++ {
+		for j := i + 1; j < len(result); j++ {
+			if len(result[j].Entries) > len(result[i].Entries) {
+				result[i], result[j] = result[j], result[i]
+			}
+		}
+	}
+
+	return result, nil
+}
+


### PR DESCRIPTION
## Summary

- Add HTTP server (`server/server.go`): routes, page handlers, S3 proxy (`/dashboard/s3`), JUnit report viewer (`/dashboard/junit`), API endpoints
- Add `base.html`: nav layout, shared CSS
- Add `deliverables.html`: pipelines overview with status badges and AI analysis dialogs
- Add `pipeline-detail.html`: per-operator version history with clickable commit SHA links to GitHub
- Add `analysis.html`: failure grouping by AI root cause
- Add `usage.html`: cluster reserves and usage
- Add `junit-report.html`: JUnit XML rendered as HTML (failures first)

## Stack

This is PR 3/4 — depends on `dashboard/pr2-data-layer`.
1. `dashboard/pr1-core-infra` — core infrastructure
2. `dashboard/pr2-data-layer` — data layer
3. **This PR** — HTTP server and UI templates
4. `dashboard/pr4-deploy-tooling` — deploy tooling and documentation

## Test plan

- [ ] `make dashboard` serves UI at `http://localhost:8080/dashboard/pipelines`
- [ ] Pipelines page shows rows, dialogs show AI summary + links
- [ ] JUnit Report link renders test results as HTML
- [ ] Logs link proxies S3 object through server

🤖 Generated with [Claude Code](https://claude.com/claude-code)